### PR TITLE
storeByte/Half/Word/Double should take Int8/16/32/64 for better clarity

### DIFF
--- a/src/ExecuteI.hs
+++ b/src/ExecuteI.hs
@@ -122,19 +122,19 @@ execute (Sb rs1 rs2 simm12) = do
   withTranslation Store 1 (a + fromIntegral simm12)
     (\addr -> do
         x <- getRegister rs2
-        storeByte addr x)
+        storeByte addr (fromIntegral x))
 execute (Sh rs1 rs2 simm12) = do
   a <- getRegister rs1
   withTranslation Store 2 (a + fromIntegral simm12)
     (\addr -> do
         x <- getRegister rs2
-        storeHalf addr x)
+        storeHalf addr (fromIntegral x))
 execute (Sw rs1 rs2 simm12) = do
   a <- getRegister rs1
   withTranslation Store 4 (a + fromIntegral simm12)
     (\addr -> do
         x <- getRegister rs2
-        storeWord addr x)
+        storeWord addr (fromIntegral x))
 execute (Addi rd rs1 imm12) = do
   x <- getRegister rs1
   setRegister rd (x + fromIntegral imm12)

--- a/src/ExecuteI64.hs
+++ b/src/ExecuteI64.hs
@@ -26,7 +26,7 @@ execute (Sd rs1 rs2 simm12) = do
   withTranslation Store 8 (a + fromIntegral simm12)
     (\addr -> do
         x <- getRegister rs2
-        storeDouble addr x)
+        storeDouble addr (fromIntegral x))
 execute (Addiw rd rs1 imm12) = do
   x <- getRegister rs1
   setRegister rd (s32 (x + fromIntegral imm12))

--- a/src/Program.hs
+++ b/src/Program.hs
@@ -17,10 +17,10 @@ class (Monad p, Convertible t u, Bounded t, Bounded u, Bits t, Bits u, MachineWi
   loadHalf :: (Integral s) => s -> p Int16
   loadWord :: (Integral s) => s -> p Int32
   loadDouble :: (Integral s) => s -> p Int64
-  storeByte :: (Integral r, Integral s, Bits r, Bits s) => r -> s -> p ()
-  storeHalf :: (Integral r, Integral s, Bits r, Bits s) => r -> s -> p ()
-  storeWord :: (Integral r, Integral s, Bits r, Bits s) => r -> s -> p ()
-  storeDouble :: (Integral r, Integral s, Bits r, Bits s) => r -> s -> p ()
+  storeByte :: (Integral s, Bits s) => s -> Int8 -> p ()
+  storeHalf :: (Integral s, Bits s) => s -> Int16 -> p ()
+  storeWord :: (Integral s, Bits s) => s -> Int32 -> p ()
+  storeDouble :: (Integral s, Bits s) => s -> Int64 -> p ()
   getCSRField :: CSRField -> p MachineInt
   setCSRField :: (Integral s) => CSRField -> s -> p ()
   getPC :: p t


### PR DESCRIPTION
Tested with `./install.sh && stack exec riscv-semantics test/build/thuemorse64` (not sure if that's enough?).