### PR TITLE
[don't merge yet] annotate (almost) all fromIntegral calls

### DIFF
--- a/src/Elf.hs
+++ b/src/Elf.hs
@@ -27,7 +27,7 @@ translateElf e = concat $ map translateElfSegment $ elfSegments e
 translateElfSegment :: ElfSegment -> [(Int, Word8)]
 translateElfSegment s =
     if elfSegmentType s == PT_LOAD
-        then addressEachByte (fromIntegral $ elfSegmentPhysAddr s) (B.unpack $ elfSegmentData s)
+        then addressEachByte ((fromIntegral:: Word64 -> Int) $ elfSegmentPhysAddr s) (B.unpack $ elfSegmentData s)
         else []
 
 addressEachByte :: Int -> [Word8] -> [(Int, Word8)]

--- a/src/ExecuteCSR.hs
+++ b/src/ExecuteCSR.hs
@@ -22,12 +22,12 @@ execute (Csrrs rd rs1 csr12) = do
   mask <- getRegister rs1
   val <- getCSR (lookupCSR csr12)
   setRegister rd val
-  when (rs1 /= 0) (setCSR (lookupCSR csr12) (val .|. (fromIntegral mask)))
+  when (rs1 /= 0) (setCSR (lookupCSR csr12) (val .|. ((fromIntegral:: t -> MachineInt) mask)))
 execute (Csrrc rd rs1 csr12) = do
   mask <- getRegister rs1
   val <- getCSR (lookupCSR csr12)
   setRegister rd val
-  when (rs1 /= 0) (setCSR (lookupCSR csr12) (val .&. (fromIntegral mask)))
+  when (rs1 /= 0) (setCSR (lookupCSR csr12) (val .&. ((fromIntegral:: t -> MachineInt) mask)))
 execute (Csrrwi rd zimm csr12) = do
   when (rd /= 0) (do
     val <- getCSR (lookupCSR csr12)
@@ -36,7 +36,7 @@ execute (Csrrwi rd zimm csr12) = do
 execute (Csrrsi rd zimm csr12) = do
   val <- getCSR (lookupCSR csr12)
   setRegister rd val
-  when (zimm /= 0) (setCSR (lookupCSR csr12) (val .|. (fromIntegral zimm)))
+  when (zimm /= 0) (setCSR (lookupCSR csr12) (val .|. zimm))
 execute (Csrrci rd zimm csr12) = do
   val <- getCSR (lookupCSR csr12)
   setRegister rd val

--- a/src/ExecuteI.hs
+++ b/src/ExecuteI.hs
@@ -23,7 +23,7 @@ execute (Jal rd jimm20) = do
   if (mod newPC 4 /= 0)
     then raiseException 0 0
     else (do
-      setRegister rd (fromIntegral pc + 4)
+      setRegister rd ((fromIntegral:: t -> MachineInt) pc + 4)
       setPC newPC)
 execute (Jalr rd rs1 oimm12) = do
   x <- getRegister rs1
@@ -32,7 +32,7 @@ execute (Jalr rd rs1 oimm12) = do
   if (mod newPC 4 /= 0)
     then raiseException 0 0
     else (do
-      setRegister rd (fromIntegral pc + 4)
+      setRegister rd ((fromIntegral:: t -> MachineInt) pc + 4)
       setPC newPC)
 execute (Beq rs1 rs2 sbimm12) = do
   x <- getRegister rs1

--- a/src/ExecuteI.hs
+++ b/src/ExecuteI.hs
@@ -6,6 +6,7 @@ import Program
 import Utility
 import VirtualMemory
 import Data.Bits
+import Data.Int
 import Data.Word
 import Control.Monad
 import Prelude
@@ -15,10 +16,10 @@ execute :: forall p t u. (RiscvProgram p t u, MonadPlus p) => Instruction -> p (
 execute (Lui rd imm20) = setRegister rd imm20
 execute (Auipc rd oimm20) = do
   pc <- getPC
-  setRegister rd (fromIntegral oimm20 + pc)
+  setRegister rd ((fromIntegral:: MachineInt -> t) oimm20 + pc)
 execute (Jal rd jimm20) = do
   pc <- getPC
-  let newPC = pc + (fromIntegral jimm20)
+  let newPC = pc + ((fromIntegral:: MachineInt -> t) jimm20)
   if (mod newPC 4 /= 0)
     then raiseException 0 0
     else (do
@@ -27,7 +28,7 @@ execute (Jal rd jimm20) = do
 execute (Jalr rd rs1 oimm12) = do
   x <- getRegister rs1
   pc <- getPC
-  let newPC = x + fromIntegral oimm12
+  let newPC = x + (fromIntegral:: MachineInt -> t) oimm12
   if (mod newPC 4 /= 0)
     then raiseException 0 0
     else (do
@@ -38,7 +39,7 @@ execute (Beq rs1 rs2 sbimm12) = do
   y <- getRegister rs2
   pc <- getPC
   when (x == y) (do
-    let newPC = (pc + fromIntegral sbimm12)
+    let newPC = (pc + (fromIntegral:: MachineInt -> t) sbimm12)
     if (mod newPC 4 /= 0)
       then raiseException 0 0
       else setPC newPC)
@@ -47,7 +48,7 @@ execute (Bne rs1 rs2 sbimm12) = do
   y <- getRegister rs2
   pc <- getPC
   when (x /= y) (do
-    let addr = (pc + fromIntegral sbimm12)
+    let addr = (pc + (fromIntegral:: MachineInt -> t) sbimm12)
     if (mod addr 4 /= 0)
       then raiseException 0 0
       else setPC addr)
@@ -56,7 +57,7 @@ execute (Blt rs1 rs2 sbimm12) = do
   y <- getRegister rs2
   pc <- getPC
   when (x < y) (do
-    let addr = (pc + fromIntegral sbimm12)
+    let addr = (pc + (fromIntegral:: MachineInt -> t) sbimm12)
     if (mod addr 4 /= 0)
       then raiseException 0 0
       else setPC addr)
@@ -65,7 +66,7 @@ execute (Bge rs1 rs2 sbimm12) = do
   y <- getRegister rs2
   pc <- getPC
   when (x >= y) (do
-    let addr = (pc + fromIntegral sbimm12)
+    let addr = (pc + (fromIntegral:: MachineInt -> t) sbimm12)
     if (mod addr 4 /= 0)
       then raiseException 0 0
       else setPC addr)
@@ -74,7 +75,7 @@ execute (Bltu rs1 rs2 sbimm12) = do
   y <- getRegister rs2
   pc <- getPC
   when ((ltu x y)) (do
-    let addr = (pc + fromIntegral sbimm12)
+    let addr = (pc + (fromIntegral:: MachineInt -> t) sbimm12)
     if (mod addr 4 /= 0)
       then raiseException 0 0
       else setPC addr)
@@ -83,76 +84,76 @@ execute (Bgeu rs1 rs2 sbimm12) = do
   y <- getRegister rs2
   pc <- getPC
   when (not (ltu x y)) (do
-    let addr = (pc + fromIntegral sbimm12)
+    let addr = (pc + (fromIntegral:: MachineInt -> t) sbimm12)
     if (mod addr 4 /= 0)
       then raiseException 0 0
       else setPC addr)
 execute (Lb rd rs1 oimm12) = do
   a <- getRegister rs1
-  withTranslation Load 1 (a + fromIntegral oimm12)
+  withTranslation Load 1 (a + (fromIntegral:: MachineInt -> t) oimm12)
     (\addr -> do
         x <- loadByte addr
         setRegister rd x)
 execute (Lh rd rs1 oimm12) = do
   a <- getRegister rs1
-  withTranslation Load 2 (a + fromIntegral oimm12)
+  withTranslation Load 2 (a + (fromIntegral:: MachineInt -> t) oimm12)
     (\addr -> do
         x <- loadHalf addr
         setRegister rd x)
 execute (Lw rd rs1 oimm12) = do
   a <- getRegister rs1
-  withTranslation Load 4 (a + fromIntegral oimm12)
+  withTranslation Load 4 (a + (fromIntegral:: MachineInt -> t) oimm12)
     (\addr -> do
         x <- loadWord addr
         setRegister rd x)
 execute (Lbu rd rs1 oimm12) = do
   a <- getRegister rs1
-  withTranslation Load 1 (a + fromIntegral oimm12)
+  withTranslation Load 1 (a + (fromIntegral:: MachineInt -> t) oimm12)
     (\addr -> do
         x <- loadByte addr
         setRegister rd (unsigned x))
 execute (Lhu rd rs1 oimm12) = do
   a <- getRegister rs1
-  withTranslation Load 2 (a + fromIntegral oimm12)
+  withTranslation Load 2 (a + (fromIntegral:: MachineInt -> t) oimm12)
     (\addr -> do
         x <- loadHalf addr
         setRegister rd (unsigned x))
 execute (Sb rs1 rs2 simm12) = do
   a <- getRegister rs1
-  withTranslation Store 1 (a + fromIntegral simm12)
+  withTranslation Store 1 (a + (fromIntegral:: MachineInt -> t) simm12)
     (\addr -> do
         x <- getRegister rs2
-        storeByte addr (fromIntegral x))
+        storeByte addr ((fromIntegral:: t -> Int8) x))
 execute (Sh rs1 rs2 simm12) = do
   a <- getRegister rs1
-  withTranslation Store 2 (a + fromIntegral simm12)
+  withTranslation Store 2 (a + (fromIntegral:: MachineInt -> t) simm12)
     (\addr -> do
         x <- getRegister rs2
-        storeHalf addr (fromIntegral x))
+        storeHalf addr ((fromIntegral:: t -> Int16) x))
 execute (Sw rs1 rs2 simm12) = do
   a <- getRegister rs1
-  withTranslation Store 4 (a + fromIntegral simm12)
+  withTranslation Store 4 (a + (fromIntegral:: MachineInt -> t) simm12)
     (\addr -> do
         x <- getRegister rs2
-        storeWord addr (fromIntegral x))
+        storeWord addr ((fromIntegral:: t -> Int32) x))
 execute (Addi rd rs1 imm12) = do
   x <- getRegister rs1
-  setRegister rd (x + fromIntegral imm12)
+  setRegister rd (x + (fromIntegral:: MachineInt -> t) imm12)
 execute (Slti rd rs1 imm12) = do
   x <- getRegister rs1 -- Why is the fromIntegral here required?
-  setRegister rd (if x < (fromIntegral imm12) then 1 else 0)
+  setRegister rd (if x < ((fromIntegral:: MachineInt -> t) imm12) then 1 else 0)
 execute (Sltiu rd rs1 imm12) = do
   x <- getRegister rs1
   setRegister rd (if (ltu x imm12) then 1 else 0)
 execute (Xori rd rs1 imm12) = do
   x <- getRegister rs1
-  setRegister rd (xor x (fromIntegral imm12))
+  setRegister rd (xor x ((fromIntegral:: MachineInt -> t) imm12))
 execute (Ori rd rs1 imm12) = do
   x <- getRegister rs1
-  setRegister rd (x .|. (fromIntegral imm12))
+  setRegister rd (x .|. ((fromIntegral:: MachineInt -> t) imm12))
 execute (Andi rd rs1 imm12) = do
   x <- getRegister rs1
-  setRegister rd (x .&. (fromIntegral imm12))
+  setRegister rd (x .&. ((fromIntegral:: MachineInt -> t) imm12))
 execute (Slli rd rs1 shamt6) = do
   x <- getRegister rs1
   setRegister rd (slli x shamt6)

--- a/src/ExecuteI64.hs
+++ b/src/ExecuteI64.hs
@@ -11,34 +11,34 @@ import Control.Monad
 execute :: forall p t u. (RiscvProgram p t u, MonadPlus p) => Instruction -> p ()
 execute (Lwu rd rs1 oimm12) = do
   a <- getRegister rs1
-  withTranslation Load 4 (a + fromIntegral oimm12)
+  withTranslation Load 4 (a + (fromIntegral:: MachineInt -> t) oimm12)
     (\addr -> do
         x <- loadWord addr
         setRegister rd (unsigned x))
 execute (Ld rd rs1 oimm12) = do
   a <- getRegister rs1
-  withTranslation Load 8 (a + fromIntegral oimm12)
+  withTranslation Load 8 (a + (fromIntegral:: MachineInt -> t) oimm12)
     (\addr -> do
         x <- loadDouble addr
         setRegister rd x)
 execute (Sd rs1 rs2 simm12) = do
   a <- getRegister rs1
-  withTranslation Store 8 (a + fromIntegral simm12)
+  withTranslation Store 8 (a + (fromIntegral:: MachineInt -> t) simm12)
     (\addr -> do
         x <- getRegister rs2
-        storeDouble addr (fromIntegral x))
+        storeDouble addr ((fromIntegral:: t -> Int64) x))
 execute (Addiw rd rs1 imm12) = do
   x <- getRegister rs1
-  setRegister rd (s32 (x + fromIntegral imm12))
+  setRegister rd (s32 (x + (fromIntegral:: MachineInt -> t) imm12))
 execute (Slliw rd rs1 imm12) = do
   x <- getRegister rs1
-  setRegister rd (s32 (shiftL x (shiftBits (fromIntegral imm12 :: Int32))))
+  setRegister rd (s32 (shiftL x (shiftBits ((fromIntegral:: MachineInt -> Int32) imm12))))
 execute (Srliw rd rs1 imm12) = do
   x <- getRegister rs1
-  setRegister rd (s32 (shiftR (u32 x) (shiftBits (fromIntegral imm12 :: Int32))))
+  setRegister rd (s32 (shiftR (u32 x) (shiftBits ((fromIntegral:: MachineInt -> Int32) imm12))))
 execute (Sraiw rd rs1 imm12) = do
   x <- getRegister rs1
-  setRegister rd (s32 (shiftR (s32 x) (shiftBits (fromIntegral imm12 :: Int32))))
+  setRegister rd (s32 (shiftR (s32 x) (shiftBits ((fromIntegral:: MachineInt -> Int32) imm12))))
 execute (Addw rd rs1 rs2) = do
   x <- getRegister rs1
   y <- getRegister rs2
@@ -50,13 +50,13 @@ execute (Subw rd rs1 rs2) = do
 execute (Sllw rd rs1 rs2) = do
   x <- getRegister rs1
   y <- getRegister rs2
-  setRegister rd (s32 (shiftL x (shiftBits (fromIntegral y :: Int32))))
+  setRegister rd (s32 (shiftL x (shiftBits ((fromIntegral:: t -> Int32) y))))
 execute (Srlw rd rs1 rs2) = do
   x <- getRegister rs1
   y <- getRegister rs2
-  setRegister rd (s32 (shiftR (u32 x) (shiftBits (fromIntegral y :: Int32))))
+  setRegister rd (s32 (shiftR (u32 x) (shiftBits ((fromIntegral:: t -> Int32) y))))
 execute (Sraw rd rs1 rs2) = do
   x <- getRegister rs1
   y <- getRegister rs2
-  setRegister rd (s32 (shiftR x (shiftBits (fromIntegral y :: Int32))))
+  setRegister rd (s32 (shiftR x (shiftBits ((fromIntegral:: t -> Int32) y))))
 execute _ = mzero

--- a/src/ExecuteM.hs
+++ b/src/ExecuteM.hs
@@ -48,7 +48,7 @@ execute (Remu rd rs1 rs2) = do
   x <- getRegister rs1
   y <- getRegister rs2
   let r | y == 0 = x
-        | otherwise = fromIntegral (rem (unsigned x) (unsigned y))
+        | otherwise = (fromIntegral:: u -> t) (rem (unsigned x) (unsigned y))
     in setRegister rd r
 -- end ast
 execute _ = mzero

--- a/src/ExecuteM.hs
+++ b/src/ExecuteM.hs
@@ -15,15 +15,15 @@ execute (Mul rd rs1 rs2) = do
 execute (Mulh rd rs1 rs2) = do
   x <- getRegister rs1
   y <- getRegister rs2
-  setRegister rd (highBits ((fromIntegral x) * (fromIntegral y))::t)
+  setRegister rd (highBits (((fromIntegral:: t -> Integer) x) * ((fromIntegral:: t -> Integer) y))::t)
 execute (Mulhsu rd rs1 rs2) = do
   x <- getRegister rs1
   y <- getRegister rs2
-  setRegister rd (highBits ((fromIntegral x) * (fromIntegral (unsigned y)))::t)
+  setRegister rd (highBits (((fromIntegral:: t -> Integer) x) * ((fromIntegral:: u -> Integer) (unsigned y)))::t)
 execute (Mulhu rd rs1 rs2) = do
   x <- getRegister rs1
   y <- getRegister rs2
-  setRegister rd (highBits ((fromIntegral ( unsigned x)) * (fromIntegral  (unsigned y)))::t)
+  setRegister rd (highBits (((fromIntegral:: u -> Integer) (unsigned x)) * ((fromIntegral:: u -> Integer)  (unsigned y)))::t)
 execute (Div rd rs1 rs2) = do
   x <- getRegister rs1
   y <- getRegister rs2

--- a/src/ExecuteM64.hs
+++ b/src/ExecuteM64.hs
@@ -34,6 +34,6 @@ execute (Remuw rd rs1 rs2) = do
   x <- getRegister rs1
   y <- getRegister rs2
   let r | y == 0 = x
-        | otherwise = fromIntegral (rem (unsigned x) (unsigned y))
+        | otherwise = (fromIntegral:: u -> t) (rem (unsigned x) (unsigned y))
     in setRegister rd (s32 r)
 execute _ = mzero

--- a/src/ListMemory.hs
+++ b/src/ListMemory.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleInstances, ScopedTypeVariables, InstanceSigs #-}
 module ListMemory where
 import Memory
 import Utility
@@ -8,11 +8,26 @@ helpStore mem addr bytes = f ++ bytes ++ drop (length bytes) s
   where (f,s) = splitAt addr mem
 
 instance Memory [Word8] where
-  loadByte mem addr = mem !! (fromIntegral addr)
-  loadHalf mem addr = combineBytes $ take 2 $ drop (fromIntegral addr) mem
-  loadWord mem addr = combineBytes $ take 4 $ drop (fromIntegral addr) mem
-  loadDouble mem addr = combineBytes $ take 8 $ drop (fromIntegral addr) mem
-  storeByte mem addr val = setIndex (fromIntegral addr) val mem
-  storeHalf mem addr val = helpStore mem (fromIntegral addr) (splitHalf val)
-  storeWord mem addr val = helpStore mem (fromIntegral addr) (splitWord val)
-  storeDouble mem addr val = helpStore mem (fromIntegral addr) (splitDouble val)
+  loadByte :: forall a. (Integral a) => [Word8] -> a -> Word8
+  loadByte mem addr = mem !! ((fromIntegral:: a -> Int) addr)
+
+  loadHalf :: forall a. (Integral a) => [Word8] -> a -> Word16
+  loadHalf mem addr = combineBytes $ take 2 $ drop ((fromIntegral:: a -> Int) addr) mem
+
+  loadWord :: forall a. (Integral a) => [Word8] -> a -> Word32
+  loadWord mem addr = combineBytes $ take 4 $ drop ((fromIntegral:: a -> Int) addr) mem
+
+  loadDouble :: forall a. (Integral a) => [Word8] -> a -> Word64
+  loadDouble mem addr = combineBytes $ take 8 $ drop ((fromIntegral:: a -> Int) addr) mem
+
+  storeByte :: forall a. (Integral a) => [Word8] -> a -> Word8 -> [Word8]
+  storeByte mem addr val = setIndex ((fromIntegral:: a -> Int) addr) val mem
+
+  storeHalf :: forall a. (Integral a) => [Word8] -> a -> Word16 -> [Word8]
+  storeHalf mem addr val = helpStore mem ((fromIntegral:: a -> Int) addr) (splitHalf val)
+
+  storeWord :: forall a. (Integral a) => [Word8] -> a -> Word32 -> [Word8]
+  storeWord mem addr val = helpStore mem ((fromIntegral:: a -> Int) addr) (splitWord val)
+
+  storeDouble :: forall a. (Integral a) => [Word8] -> a -> Word64 -> [Word8]
+  storeDouble mem addr val = helpStore mem ((fromIntegral:: a -> Int) addr) (splitDouble val)

--- a/src/MMIO.hs
+++ b/src/MMIO.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, FlexibleContexts, MultiWayIf, UndecidableInstances #-}
+{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, FlexibleContexts, MultiWayIf, UndecidableInstances, ScopedTypeVariables, InstanceSigs #-}
 module MMIO where
 import Data.Bits
 import Data.Int
@@ -22,12 +22,12 @@ instance (Show (StoreFunc s)) where
   show _ = "<io/storefunc>"
 
 cGetChar :: IO Int32
-cGetChar = catchIOError (fmap (fromIntegral . ord) getChar) (\e -> if isEOFError e then return (-1) else ioError e)
+cGetChar = catchIOError (fmap ((fromIntegral:: Int -> Int32). ord) getChar) (\e -> if isEOFError e then return (-1) else ioError e)
 
 rvGetChar :: LoadFunc s
 rvGetChar = liftIO cGetChar
 rvPutChar :: StoreFunc s
-rvPutChar val = liftIO (putChar $ chr $ fromIntegral val)
+rvPutChar val = liftIO (putChar $ chr $ (fromIntegral:: Int32 -> Int) val)
 
 -- Addresses for mtime/mtimecmp chosen for Spike compatibility.
 mmioTable :: S.Map MachineInt (LoadFunc s, StoreFunc s)
@@ -41,16 +41,18 @@ instance (RiscvProgram (State s) t u, Convertible t u, Bounded t, Bounded u, Bit
   setRegister r v = liftState (setRegister r v)
   loadByte a = liftState (loadByte a)
   loadHalf a = liftState (loadHalf a)
+  loadWord :: forall a. (Integral a) => a -> IOState s Int32
   loadWord addr =
-    case S.lookup (fromIntegral addr) mmioTable of
+    case S.lookup ((fromIntegral:: a -> MachineInt) addr) mmioTable of
       Just (getFunc, _) -> getFunc
       Nothing -> liftState (loadWord addr)
   loadDouble a = liftState (loadDouble a)
   storeByte a v = liftState (storeByte a v)
   storeHalf a v = liftState (storeHalf a v)
+  storeWord :: forall a. (Integral a, Bits a) => a -> Int32 -> IOState s ()
   storeWord addr val =
-    case S.lookup (fromIntegral addr) mmioTable of
-      Just (_, setFunc) -> setFunc (fromIntegral val)
+    case S.lookup ((fromIntegral:: a -> MachineInt) addr) mmioTable of
+      Just (_, setFunc) -> setFunc val
       Nothing -> liftState (storeWord addr val)
   storeDouble a v = liftState (storeDouble a v)
   getCSRField f = liftState (getCSRField f)

--- a/src/MapMemory.hs
+++ b/src/MapMemory.hs
@@ -1,16 +1,23 @@
-{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleInstances, ScopedTypeVariables #-}
 module MapMemory where
 import Memory
 import Utility
 import Data.Maybe
 import Data.Word
+import Data.Bits
 import qualified Data.Map as S
 
-readM mem addr = fromMaybe 0 (S.lookup (fromIntegral addr) mem)
-writeM mem addr val = S.insert (fromIntegral addr) val mem
+readM :: forall a. (Integral a) => (S.Map Int Word8) -> a -> Word8
+readM mem addr = fromMaybe 0 (S.lookup ((fromIntegral:: a -> Int) addr) mem)
 
+writeM :: forall a. (Integral a) => (S.Map Int Word8) -> a -> Word8 -> (S.Map Int Word8)
+writeM mem addr val = S.insert ((fromIntegral:: a -> Int) addr) val mem
+
+helpLoad :: forall a b. (Integral a, Bits b, Integral b) => (S.Map Int Word8) -> a -> Int -> b
 helpLoad mem addr numBytes =
   combineBytes $ fmap (\a -> readM mem a) [(fromIntegral addr)..(fromIntegral addr + numBytes - 1)]
+
+helpStore :: forall a. (Integral a) => (S.Map Int Word8) -> a -> [Word8] -> (S.Map Int Word8)
 helpStore mem addr bytes =
   foldr (\(b,a) m -> writeM m a b) mem $ zip bytes [addr + i | i <- [0..]]
 

--- a/src/MapMemory.hs
+++ b/src/MapMemory.hs
@@ -15,7 +15,7 @@ writeM mem addr val = S.insert ((fromIntegral:: a -> Int) addr) val mem
 
 helpLoad :: forall a b. (Integral a, Bits b, Integral b) => (S.Map Int Word8) -> a -> Int -> b
 helpLoad mem addr numBytes =
-  combineBytes $ fmap (\a -> readM mem a) [(fromIntegral addr)..(fromIntegral addr + numBytes - 1)]
+  combineBytes $ fmap (\a -> readM mem a) [((fromIntegral:: a -> Int) addr)..((fromIntegral:: a -> Int) addr + numBytes - 1)]
 
 helpStore :: forall a. (Integral a) => (S.Map Int Word8) -> a -> [Word8] -> (S.Map Int Word8)
 helpStore mem addr bytes =

--- a/src/Minimal32.hs
+++ b/src/Minimal32.hs
@@ -1,11 +1,13 @@
-{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, ScopedTypeVariables, InstanceSigs #-}
 module Minimal32 where
 import Program
+import Decode
 import Utility
 import CSRFile
 import qualified CSRField as Field
 import qualified Memory as M
 import MapMemory()
+import Data.Bits
 import Data.Int
 import Data.Word
 import qualified Data.Map as S
@@ -26,7 +28,7 @@ instance (Show StoreFunc) where
   show _ = "<storefunc>"
 
 getMTime :: LoadFunc
-getMTime = fmap fromIntegral (getCSRField Field.MCycle)
+getMTime = fmap (fromIntegral:: MachineInt -> Int32) (getCSRField Field.MCycle)
 
 -- Ignore writes to mtime.
 setMTime :: StoreFunc
@@ -37,16 +39,18 @@ memMapTable :: S.Map MachineInt (LoadFunc, StoreFunc)
 memMapTable = S.fromList [(0x200bff8, (getMTime, setMTime))]
 mtimecmp_addr = 0x2004000
 
-wrapLoad :: (Integral a, Integral a', Integral r, Integral r') => (S.Map Int Word8 -> a -> r) -> (a' -> MState r')
-wrapLoad loadFunc addr = state $ \comp -> (fromIntegral $ loadFunc (mem comp) (fromIntegral (fromIntegral addr :: Word32)), comp)
-wrapStore :: (Integral a, Integral a', Integral v, Integral v') => (S.Map Int Word8 -> a -> v -> S.Map Int Word8) -> (a' -> v' -> MState ())
-wrapStore storeFunc addr val = state $ \comp -> ((), comp { mem = storeFunc (mem comp) (fromIntegral (fromIntegral addr :: Word32)) (fromIntegral val) })
+wrapLoad :: forall a a' r r'. (Integral a, Integral a', Integral r, Integral r') => (S.Map Int Word8 -> a -> r) -> (a' -> MState r')
+wrapLoad loadFunc addr = state $ \comp -> ((fromIntegral:: r -> r') $ loadFunc (mem comp) ((fromIntegral:: Word32 -> a) ((fromIntegral:: a' -> Word32) addr)), comp)
+wrapStore :: forall a a' v v'. (Integral a, Integral a', Integral v, Integral v') => (S.Map Int Word8 -> a -> v -> S.Map Int Word8) -> (a' -> v' -> MState ())
+wrapStore storeFunc addr val = state $ \comp -> ((), comp { mem = storeFunc (mem comp) ((fromIntegral:: Word32 -> a) ((fromIntegral:: a' -> Word32) addr)) ((fromIntegral:: v' -> v) val) })
 
 instance RiscvProgram MState Int32 Word32 where
-  getRegister reg = state $ \comp -> (if reg == 0 then 0 else (registers comp) !! (fromIntegral reg-1), comp)
-  setRegister reg val = state $ \comp -> ((), if reg == 0 then comp else comp { registers = setIndex (fromIntegral reg-1) (fromIntegral val) (registers comp) })
+  getRegister reg = state $ \comp -> (if reg == 0 then 0 else (registers comp) !! ((fromIntegral:: Register -> Int) reg-1), comp)
+  setRegister :: forall s. (Integral s) => Register -> s -> MState ()
+  setRegister reg val = state $ \comp -> ((), if reg == 0 then comp else comp { registers = setIndex ((fromIntegral:: Register -> Int) reg-1) ((fromIntegral:: s -> Int32) val) (registers comp) })
   getPC = state $ \comp -> (pc comp, comp)
-  setPC val = state $ \comp -> ((), comp { nextPC = fromIntegral val })
+  setPC :: forall s. (Integral s) => s -> MState ()
+  setPC val = state $ \comp -> ((), comp { nextPC = (fromIntegral:: s -> Int32) val })
   step = do
     -- Post interrupt if mtime >= mtimecmp
     mtime <- getMTime
@@ -72,25 +76,28 @@ instance RiscvProgram MState Int32 Word32 where
               -- Save the PC of the next (unexecuted) instruction.
               setCSRField Field.MEPC nPC
               trapPC <- getCSRField Field.MTVecBase
-              return (fromIntegral trapPC * 4)
+              return ((fromIntegral:: MachineInt -> Int32) trapPC * 4)
             else return nPC)
     state $ \comp -> ((), comp { pc = fPC })
   -- Wrap Memory instance:
   loadByte = wrapLoad M.loadByte
   loadHalf = wrapLoad M.loadHalf
+  loadWord :: forall s. (Integral s) => s -> MState Int32
   loadWord addr =
-    case S.lookup (fromIntegral addr) memMapTable of
+    case S.lookup ((fromIntegral:: s -> MachineInt) addr) memMapTable of
       Just (getFunc, _) -> getFunc
       Nothing -> wrapLoad M.loadWord addr
   storeByte = wrapStore M.storeByte
   storeHalf = wrapStore M.storeHalf
+  storeWord :: forall s. (Integral s, Bits s) => s -> Int32 -> MState ()
   storeWord addr val =
-    case S.lookup (fromIntegral addr) memMapTable of
-      Just (_, setFunc) -> setFunc (fromIntegral val)
+    case S.lookup ((fromIntegral:: s -> MachineInt) addr) memMapTable of
+      Just (_, setFunc) -> setFunc val
       Nothing -> wrapStore M.storeWord addr val
   -- CSRs:
   getCSRField field = state $ \comp -> (getField field (csrs comp), comp)
-  setCSRField field val = state $ \comp -> ((), comp { csrs = setField field (fromIntegral val) (csrs comp) })
+  setCSRField :: forall s. (Integral s) => Field.CSRField -> s -> MState ()
+  setCSRField field val = state $ \comp -> ((), comp { csrs = setField field ((fromIntegral:: s -> MachineInt) val) (csrs comp) })
   -- Unimplemented:
   loadDouble _ = return 0
   storeDouble _ _ = return ()

--- a/src/Minimal64.hs
+++ b/src/Minimal64.hs
@@ -1,11 +1,13 @@
-{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, ScopedTypeVariables, InstanceSigs #-}
 module Minimal64 where
 import Program
+import Decode
 import Utility
 import CSRFile
 import qualified CSRField as Field
 import qualified Memory as M
 import MapMemory()
+import Data.Bits
 import Data.Int
 import Data.Word
 import qualified Data.Map as S
@@ -26,7 +28,7 @@ instance (Show StoreFunc) where
   show _ = "<storefunc>"
 
 getMTime :: LoadFunc
-getMTime = fmap fromIntegral (getCSRField Field.MCycle)
+getMTime = fmap (fromIntegral:: MachineInt -> Int32) (getCSRField Field.MCycle)
 
 -- Ignore writes to mtime.
 setMTime :: StoreFunc
@@ -37,16 +39,18 @@ memMapTable :: S.Map MachineInt (LoadFunc, StoreFunc)
 memMapTable = S.fromList [(0x200bff8, (getMTime, setMTime))]
 mtimecmp_addr = 0x2004000
 
-wrapLoad :: (Integral a, Integral a', Integral r, Integral r') => (S.Map Int Word8 -> a -> r) -> (a' -> MState r')
-wrapLoad loadFunc addr = state $ \comp -> (fromIntegral $ loadFunc (mem comp) (fromIntegral (fromIntegral addr :: Word64)), comp)
-wrapStore :: (Integral a, Integral a', Integral v, Integral v') => (S.Map Int Word8 -> a -> v -> S.Map Int Word8) -> (a' -> v' -> MState ())
-wrapStore storeFunc addr val = state $ \comp -> ((), comp { mem = storeFunc (mem comp) (fromIntegral (fromIntegral addr :: Word64)) (fromIntegral val) })
+wrapLoad :: forall a a' r r'. (Integral a, Integral a', Integral r, Integral r') => (S.Map Int Word8 -> a -> r) -> (a' -> MState r')
+wrapLoad loadFunc addr = state $ \comp -> ((fromIntegral:: r -> r') $ loadFunc (mem comp) ((fromIntegral:: Word64 -> a) ((fromIntegral:: a' -> Word64) addr)), comp)
+wrapStore :: forall a a' v v'. (Integral a, Integral a', Integral v, Integral v') => (S.Map Int Word8 -> a -> v -> S.Map Int Word8) -> (a' -> v' -> MState ())
+wrapStore storeFunc addr val = state $ \comp -> ((), comp { mem = storeFunc (mem comp) ((fromIntegral:: Word64 -> a) ((fromIntegral:: a' -> Word64) addr)) ((fromIntegral:: v' -> v) val) })
 
 instance RiscvProgram MState Int64 Word64 where
-  getRegister reg = state $ \comp -> (if reg == 0 then 0 else (registers comp) !! (fromIntegral reg-1), comp)
-  setRegister reg val = state $ \comp -> ((), if reg == 0 then comp else comp { registers = setIndex (fromIntegral reg-1) (fromIntegral val) (registers comp) })
+  getRegister reg = state $ \comp -> (if reg == 0 then 0 else (registers comp) !! ((fromIntegral:: Register -> Int) reg-1), comp)
+  setRegister :: forall s. (Integral s) => Register -> s -> MState ()
+  setRegister reg val = state $ \comp -> ((), if reg == 0 then comp else comp { registers = setIndex ((fromIntegral:: Register -> Int) reg-1) ((fromIntegral:: s -> Int64) val) (registers comp) })
   getPC = state $ \comp -> (pc comp, comp)
-  setPC val = state $ \comp -> ((), comp { nextPC = fromIntegral val })
+  setPC :: forall s. (Integral s) => s -> MState ()
+  setPC val = state $ \comp -> ((), comp { nextPC = (fromIntegral:: s -> Int64) val })
   step = do
     -- Post interrupt if mtime >= mtimecmp
     mtime <- getMTime
@@ -72,24 +76,27 @@ instance RiscvProgram MState Int64 Word64 where
               -- Save the PC of the next (unexecuted) instruction.
               setCSRField Field.MEPC nPC
               trapPC <- getCSRField Field.MTVecBase
-              return (trapPC * 4)
+              return ((fromIntegral:: MachineInt -> Int64) trapPC * 4)
             else return nPC)
     state $ \comp -> ((), comp { pc = fPC })
   -- Wrap Memory instance:
   loadByte = wrapLoad M.loadByte
   loadHalf = wrapLoad M.loadHalf
+  loadWord :: forall s. (Integral s) => s -> MState Int32
   loadWord addr =
-    case S.lookup (fromIntegral addr) memMapTable of
+    case S.lookup ((fromIntegral:: s -> MachineInt) addr) memMapTable of
       Just (getFunc, _) -> getFunc
       Nothing -> wrapLoad M.loadWord addr
   loadDouble = wrapLoad M.loadDouble
   storeByte = wrapStore M.storeByte
   storeHalf = wrapStore M.storeHalf
+  storeWord :: forall s. (Integral s, Bits s) => s -> Int32 -> MState ()
   storeWord addr val =
-    case S.lookup (fromIntegral addr) memMapTable of
-      Just (_, setFunc) -> setFunc (fromIntegral val)
+    case S.lookup ((fromIntegral:: s -> MachineInt) addr) memMapTable of
+      Just (_, setFunc) -> setFunc val
       Nothing -> wrapStore M.storeWord addr val
   storeDouble = wrapStore M.storeDouble
   -- CSRs:
   getCSRField field = state $ \comp -> (getField field (csrs comp), comp)
-  setCSRField field val = state $ \comp -> ((), comp { csrs = setField field (fromIntegral val) (csrs comp) })
+  setCSRField :: forall s. (Integral s) => Field.CSRField -> s -> MState ()
+  setCSRField field val = state $ \comp -> ((), comp { csrs = setField field ((fromIntegral:: s -> MachineInt) val) (csrs comp) })

--- a/src/Program.hs
+++ b/src/Program.hs
@@ -61,13 +61,13 @@ raiseException isInterrupt exceptionCode = do
   setPC (addr * 4)
 
 slli :: forall t u .(Convertible t u, Bounded t, Bounded u, Bits t, Bits u, MachineWidth t) => t -> MachineInt -> t
-slli x shamt6 = (shiftL x (shiftBits (fromIntegral shamt6 :: t)))
+slli x shamt6 = (shiftL x (shiftBits ((fromIntegral:: MachineInt -> t) shamt6)))
 
 srli :: forall t u . (Convertible t u, Bounded t, Bounded u, Bits t, Bits u, MachineWidth t) => t -> MachineInt -> u
-srli x shamt6 = (shiftR ((unsigned x) :: u) (shiftBits (fromIntegral shamt6 :: t)))
+srli x shamt6 = (shiftR ((unsigned x) :: u) (shiftBits ((fromIntegral:: MachineInt -> t) shamt6)))
 
 srai :: forall t u . (Convertible t u, Bounded t, Bounded u, Bits t, Bits u, MachineWidth t) => t -> MachineInt -> t
-srai x shamt6 = (shiftR x (shiftBits (fromIntegral shamt6 :: t)))
+srai x shamt6 = (shiftR x (shiftBits ((fromIntegral:: MachineInt -> t) shamt6)))
 
 sll x y = (shiftL x (shiftBits y))
 srl x y = (shiftR (unsigned x) (shiftBits y))
@@ -75,5 +75,5 @@ sra x y =(shiftR x (shiftBits y))
 
 
 ltu :: forall t u s . (Convertible t u, Integral s, Bounded t, Bounded u, Bits t, Bits u, MachineWidth t) => t -> s -> Bool
-ltu x y = (unsigned  x) < (fromIntegral y :: u)
+ltu x y = (unsigned  x) < ((fromIntegral:: s -> u) y)
 

--- a/src/Run.hs
+++ b/src/Run.hs
@@ -75,7 +75,7 @@ helper maybeToHostAddress = do
         else do
         setPC (pc + 4)
         size <- getXLEN
-        execute (decode size $ fromIntegral inst)
+        execute (decode size $ (fromIntegral:: Int32 -> MachineInt) inst)
         interrupt <- liftIO checkInterrupt
         if interrupt then do
           -- Signal interrupt by setting MEIP high.
@@ -96,7 +96,7 @@ readProgram f = do
     else do
     mem <- readElf f
     maybeToHostAddress <- readElfSymbol "tohost" f
-    return (fmap fromIntegral maybeToHostAddress, mem)
+    return (fmap (fromIntegral:: Word64 -> Int64) maybeToHostAddress, mem)
 
 runFile :: String -> IO Int64
 runFile f = do
@@ -124,4 +124,4 @@ main = do
       return 1
     [file] -> runFile file
     files -> runFiles files
-  exitWith (if retval == 0 then ExitSuccess else ExitFailure $ fromIntegral retval)
+  exitWith (if retval == 0 then ExitSuccess else ExitFailure $ (fromIntegral:: Int64 -> Int) retval)

--- a/src/Utility.hs
+++ b/src/Utility.hs
@@ -16,43 +16,43 @@ setIndex :: Int -> a -> [a] -> [a]
 setIndex i x l = left ++ (x:(drop 1 right))
   where (left, right) = splitAt i l
 
-s8 :: (Integral t) => t -> t
-s8 n = fromIntegral (fromIntegral n :: Int8)
+s8 :: forall t. (Integral t) => t -> t
+s8 n = (fromIntegral:: Int8 -> t) ((fromIntegral:: t -> Int8) n)
 {-# INLINE s8 #-}
 
-s16 :: (Integral t) => t -> t
-s16 n = fromIntegral (fromIntegral n :: Int16)
+s16 :: forall t. (Integral t) => t -> t
+s16 n = (fromIntegral:: Int16 -> t) ((fromIntegral:: t -> Int16) n)
 {-# INLINE s16 #-}
 
-s32 :: (Integral t) => t -> t
-s32 n = fromIntegral (fromIntegral n :: Int32)
+s32 :: forall t. (Integral t) => t -> t
+s32 n = (fromIntegral:: Int32 -> t) ((fromIntegral:: t -> Int32) n)
 {-# INLINE s32 #-}
 
-u8 :: (Integral t) => t -> t
-u8 n = fromIntegral (fromIntegral n :: Word8)
+u8 :: forall t. (Integral t) => t -> t
+u8 n = (fromIntegral:: Word8 -> t) ((fromIntegral:: t -> Word8) n)
 {-# INLINE u8 #-}
 
-u16 :: (Integral t) => t -> t
-u16 n = fromIntegral (fromIntegral n :: Word16)
+u16 :: forall t. (Integral t) => t -> t
+u16 n = (fromIntegral:: Word16 -> t) ((fromIntegral:: t -> Word16) n)
 {-# INLINE u16 #-}
 
-u32 :: (Integral t) => t -> t
-u32 n = fromIntegral (fromIntegral n :: Word32)
+u32 :: forall t. (Integral t) => t -> t
+u32 n = (fromIntegral:: Word32 -> t) ((fromIntegral:: t -> Word32) n)
 {-# INLINE u32 #-}
 
-lower :: (Bits a, Integral a, Num b) => Int -> a -> b
-lower n x = fromIntegral $ bitSlice x 0 n
+lower :: forall a b. (Bits a, Integral a, Num b) => Int -> a -> b
+lower n x = (fromIntegral:: a -> b) $ bitSlice x 0 n
 {-# INLINE lower #-}
 
-combineBytes :: (Bits a, Integral a) => [Word8] -> a
-combineBytes bytes = foldr (\(x,n) res -> res .|. shiftL (fromIntegral n) (8*x)) 0 $ zip [0..] bytes
+combineBytes :: forall a. (Bits a, Integral a) => [Word8] -> a
+combineBytes bytes = foldr (\(x,n) res -> res .|. shiftL ((fromIntegral:: Word8 -> a) n) (8*x)) 0 $ zip [0..] bytes
 {-# INLINE combineBytes #-}
 {-# SPECIALIZE combineBytes :: [Word8] -> Word64 #-}
 {-# SPECIALIZE combineBytes :: [Word8] -> Word32 #-}
 {-# SPECIALIZE combineBytes :: [Word8] -> Word16 #-}
 
-splitBytes :: (Bits a, Integral a) => Int -> a -> [Word8]
-splitBytes n w = map fromIntegral [bitSlice w p (p + 8) | p <- [0,8..n-1]]
+splitBytes :: forall a. (Bits a, Integral a) => Int -> a -> [Word8]
+splitBytes n w = map (fromIntegral:: a -> Word8)  [bitSlice w p (p + 8) | p <- [0,8..n-1]]
 
 splitHalf :: (Bits a, Integral a) => a -> [Word8]
 splitHalf = splitBytes 16
@@ -68,9 +68,9 @@ splitDouble = splitBytes 64
 
 class (Integral s, Integral u) => Convertible s u | s -> u, u -> s where
   unsigned :: s -> u
-  unsigned = fromIntegral
+  unsigned = (fromIntegral:: s -> u)
   signed :: u -> s
-  signed = fromIntegral
+  signed = (fromIntegral:: u -> s)
 
 instance Convertible Int8 Word8
 instance Convertible Int16 Word16
@@ -84,8 +84,8 @@ class MachineWidth t where
 
 instance MachineWidth Int32 where
   shiftBits = lower 5
-  highBits n = fromIntegral $ bitSlice n 32 64
+  highBits n = (fromIntegral:: Integer -> Int32) $ bitSlice n 32 64
 
 instance MachineWidth Int64 where
   shiftBits = lower 6
-  highBits n = fromIntegral $ bitSlice n 64 128
+  highBits n = (fromIntegral:: Integer -> Int64) $ bitSlice n 64 128


### PR DESCRIPTION
To make the spec more understandable, and to prepare a potential renaming of some `fromIntegral` calls, I annotated (almost) all uses of `fromIntegral`.

However, there were a few where my understanding of Haskell was not sufficient to infer the types (it seems to me that the problem is underspecified and I don't know what the default the compiler picks):

```
src/MapMemory.hs:18:  combineBytes $ fmap (\a -> readM mem a) [(fromIntegral addr)..(fromIntegral addr + numBytes - 1)]
src/ExecuteM64.hs:37:        | otherwise = fromIntegral (rem (unsigned x) (unsigned y))
src/ExecuteM.hs:51:        | otherwise = fromIntegral (rem (unsigned x) (unsigned y))
src/ExecuteI.hs:26:      setRegister rd (fromIntegral pc + 4)
src/ExecuteI.hs:35:      setRegister rd (fromIntegral pc + 4)
```
