### PR TITLE
Composition of execute functions discards exceptions

### DIFF
--- a/src/Test.hs
+++ b/src/Test.hs
@@ -20,11 +20,14 @@ data Test = Test { name :: String, input :: String, returnValue :: Int64, output
 runTest :: Test -> IO Bool
 runTest (Test name input returnValue output) = do
   result <- runFile ("test/build/" ++ name ++ "64") input
-  return $ result == (returnValue, output)
+  let isSuccess = (result == (returnValue, output))
+  when (not isSuccess) (putStrLn ("Running " ++ name ++ " gave output " ++ show result ++ " but expected " ++ show (returnValue, output)))
+  return $ isSuccess
 
 -- TODO: Read this from a file.
 tests :: [Test]
 tests = [Test "add" ""  11 "",
+         Test "ebreak" "" 0 "D\n?\n",
          Test "sub" ""   7 "",
          Test "mul" ""  42 "",
          Test "and" ""  35 "",

--- a/test/src/ebreak.c
+++ b/test/src/ebreak.c
@@ -1,0 +1,26 @@
+#include "../trap_handler.h"
+#include "../mmio.h"
+
+// https://stackoverflow.com/questions/20029892/what-is-the-colon-in-the-c-language-between-two-strings
+
+void trap_handler() {
+  // register char causechar asm ("x15");
+  // asm volatile("csrr x15,mcause");
+  register char causechar;
+  asm volatile("csrr %0,mcause" : "=r"(causechar));
+
+  causechar += 'A';
+  putchar(causechar);
+  putchar('\n');
+}
+
+int main() {
+  // register trap handler
+  asm volatile("csrrw zero,mtvec,%0" :: "r" (_trap_handler));
+  // execute instruction which causes exception
+  asm volatile("ebreak");
+  // only runs after trap handler
+  putchar('?');
+  putchar('\n');
+  return 0;
+}


### PR DESCRIPTION
Here's a test which fails, but should not fail as far as I understand.

Here's what I think happens: In `Execute.hs`, which composes the different `execute` functions, when one of the execute functions calls `raiseException`, this results in `Nothing` being returned, which is the same as if one of the `execute` functions had returned `mzero`, so `msum` just picks the result of the next `execute` function. That is, whenever one of the `execute` functions raises an exception, the main `execute` function just falls through to `Unsupported.execute`, so the observed exception cause is always 2, even if it should be 3, such as when calling `EBREAK`.