### PR TITLE
Unsupported instruction trap handler test

### DIFF
--- a/src/Decode.hs
+++ b/src/Decode.hs
@@ -197,13 +197,13 @@ applyByExtInstructionMapper m inst = case inst of
 
   Jal {} -> map_I m inst
 
-  Ecall {} -> map_I m inst
-  Ebreak {} -> map_I m inst
-  Uret {} -> map_I m inst
-  Sret {} -> map_I m inst
-  Mret {} -> map_I m inst
-  Wfi {} -> map_I m inst
-  Sfence_vm {} -> map_I m inst
+  Ecall {} -> map_CSR m inst
+  Ebreak {} -> map_CSR m inst
+  Uret {} -> map_CSR m inst
+  Sret {} -> map_CSR m inst
+  Mret {} -> map_CSR m inst
+  Wfi {} -> map_CSR m inst
+  Sfence_vm {} -> map_CSR m inst
 
   Csrrw {} -> map_CSR m inst
   Csrrs {} -> map_CSR m inst

--- a/src/Decode.hs
+++ b/src/Decode.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+
 module Decode where
 
 -- Haskell lib imports
@@ -12,16 +14,12 @@ import Utility
 -- ================================================================
 -- Decoded instructions
 
-data Instruction =
-  InvalidInstruction |
-
+data InstructionI =
   Lb { rd :: Register, rs1 :: Register, oimm12 :: MachineInt } |
   Lh { rd :: Register, rs1 :: Register, oimm12 :: MachineInt } |
   Lw { rd :: Register, rs1 :: Register, oimm12 :: MachineInt } |
-  Ld { rd :: Register, rs1 :: Register, oimm12 :: MachineInt } |
   Lbu { rd :: Register, rs1 :: Register, oimm12 :: MachineInt } |
   Lhu { rd :: Register, rs1 :: Register, oimm12 :: MachineInt } |
-  Lwu { rd :: Register, rs1 :: Register, oimm12 :: MachineInt } |
 
   Fence { pred :: MachineInt, succ :: MachineInt } |
   Fence_i |
@@ -38,15 +36,9 @@ data Instruction =
 
   Auipc { rd :: Register, oimm20 :: MachineInt } |
 
-  Addiw { rd :: Register, rs1 :: Register, imm12 :: MachineInt } |
-  Slliw { rd :: Register, rs1 :: Register, shamt5 :: MachineInt } |
-  Srliw { rd :: Register, rs1 :: Register, shamt5 :: MachineInt } |
-  Sraiw { rd :: Register, rs1 :: Register, shamt5 :: MachineInt } |
-
   Sb { rs1 :: Register, rs2 :: Register, simm12 :: MachineInt } |
   Sh { rs1 :: Register, rs2 :: Register, simm12 :: MachineInt } |
   Sw { rs1 :: Register, rs2 :: Register, simm12 :: MachineInt } |
-  Sd { rs1 :: Register, rs2 :: Register, simm12 :: MachineInt } |
 
   Add { rd :: Register, rs1 :: Register, rs2 :: Register } |
   Sub { rd :: Register, rs1 :: Register, rs2 :: Register } |
@@ -58,27 +50,8 @@ data Instruction =
   Sra { rd :: Register, rs1 :: Register, rs2 :: Register } |
   Or { rd :: Register, rs1 :: Register, rs2 :: Register } |
   And { rd :: Register, rs1 :: Register, rs2 :: Register } |
-  Mul { rd :: Register, rs1 :: Register, rs2 :: Register } |
-  Mulh { rd :: Register, rs1 :: Register, rs2 :: Register } |
-  Mulhsu { rd :: Register, rs1 :: Register, rs2 :: Register } |
-  Mulhu { rd :: Register, rs1 :: Register, rs2 :: Register } |
-  Div { rd :: Register, rs1 :: Register, rs2 :: Register } |
-  Divu { rd :: Register, rs1 :: Register, rs2 :: Register } |
-  Rem { rd :: Register, rs1 :: Register, rs2 :: Register } |
-  Remu { rd :: Register, rs1 :: Register, rs2 :: Register } |
 
   Lui { rd :: Register, imm20 :: MachineInt } |
-
-  Addw { rd :: Register, rs1 :: Register, rs2 :: Register } |
-  Subw { rd :: Register, rs1 :: Register, rs2 :: Register } |
-  Sllw { rd :: Register, rs1 :: Register, rs2 :: Register } |
-  Srlw { rd :: Register, rs1 :: Register, rs2 :: Register } |
-  Sraw { rd :: Register, rs1 :: Register, rs2 :: Register } |
-  Mulw { rd :: Register, rs1 :: Register, rs2 :: Register } |
-  Divw { rd :: Register, rs1 :: Register, rs2 :: Register } |
-  Divuw { rd :: Register, rs1 :: Register, rs2 :: Register } |
-  Remw { rd :: Register, rs1 :: Register, rs2 :: Register } |
-  Remuw { rd :: Register, rs1 :: Register, rs2 :: Register } |
 
   Beq { rs1 :: Register, rs2 :: Register, sbimm12 :: MachineInt } |
   Bne { rs1 :: Register, rs2 :: Register, sbimm12 :: MachineInt } |
@@ -88,9 +61,57 @@ data Instruction =
   Bgeu { rs1 :: Register, rs2 :: Register, sbimm12 :: MachineInt } |
 
   Jalr { rd :: Register, rs1 :: Register, oimm12 :: MachineInt } |
-
   Jal { rd :: Register, jimm20 :: MachineInt } |
 
+  InvalidI
+  deriving (Eq, Read, Show)
+
+
+data InstructionM =
+  Mul { rd :: Register, rs1 :: Register, rs2 :: Register } |
+  Mulh { rd :: Register, rs1 :: Register, rs2 :: Register } |
+  Mulhsu { rd :: Register, rs1 :: Register, rs2 :: Register } |
+  Mulhu { rd :: Register, rs1 :: Register, rs2 :: Register } |
+  Div { rd :: Register, rs1 :: Register, rs2 :: Register } |
+  Divu { rd :: Register, rs1 :: Register, rs2 :: Register } |
+  Rem { rd :: Register, rs1 :: Register, rs2 :: Register } |
+  Remu { rd :: Register, rs1 :: Register, rs2 :: Register } |
+  InvalidM
+  deriving (Eq, Read, Show)
+
+
+data InstructionI64 =
+  Ld { rd :: Register, rs1 :: Register, oimm12 :: MachineInt } |
+  Lwu { rd :: Register, rs1 :: Register, oimm12 :: MachineInt } |
+
+  Addiw { rd :: Register, rs1 :: Register, imm12 :: MachineInt } |
+  Slliw { rd :: Register, rs1 :: Register, shamt5 :: MachineInt } |
+  Srliw { rd :: Register, rs1 :: Register, shamt5 :: MachineInt } |
+  Sraiw { rd :: Register, rs1 :: Register, shamt5 :: MachineInt } |
+
+  Sd { rs1 :: Register, rs2 :: Register, simm12 :: MachineInt } |
+
+  Addw { rd :: Register, rs1 :: Register, rs2 :: Register } |
+  Subw { rd :: Register, rs1 :: Register, rs2 :: Register } |
+  Sllw { rd :: Register, rs1 :: Register, rs2 :: Register } |
+  Srlw { rd :: Register, rs1 :: Register, rs2 :: Register } |
+  Sraw { rd :: Register, rs1 :: Register, rs2 :: Register } |
+
+  InvalidI64
+  deriving (Eq, Read, Show)
+
+
+data InstructionM64 =
+  Mulw { rd :: Register, rs1 :: Register, rs2 :: Register } |
+  Divw { rd :: Register, rs1 :: Register, rs2 :: Register } |
+  Divuw { rd :: Register, rs1 :: Register, rs2 :: Register } |
+  Remw { rd :: Register, rs1 :: Register, rs2 :: Register } |
+  Remuw { rd :: Register, rs1 :: Register, rs2 :: Register } |
+  InvalidM64
+  deriving (Eq, Read, Show)
+
+
+data InstructionCSR =
   Ecall |
   Ebreak |
   Uret |
@@ -98,120 +119,26 @@ data Instruction =
   Mret |
   Wfi |
   Sfence_vm { rs1 :: Register, rs2 :: Register } |
-
   Csrrw { rd :: Register, rs1 :: Register, csr12 :: MachineInt } |
   Csrrs { rd :: Register, rs1 :: Register, csr12 :: MachineInt } |
   Csrrc { rd :: Register, rs1 :: Register, csr12 :: MachineInt } |
   Csrrwi { rd :: Register, zimm :: MachineInt, csr12 :: MachineInt } |
   Csrrsi { rd :: Register, zimm :: MachineInt, csr12 :: MachineInt } |
-  Csrrci { rd :: Register, zimm :: MachineInt, csr12 :: MachineInt }
+  Csrrci { rd :: Register, zimm :: MachineInt, csr12 :: MachineInt } |
+  InvalidCSR
+  deriving (Eq, Read, Show)
+
+
+data Instruction =
+  IInstruction   { iInstruction   :: InstructionI   } |
+  MInstruction   { mInstruction   :: InstructionM   } |
+  I64Instruction { i64Instruction :: InstructionI64 } |
+  M64Instruction { m64Instruction :: InstructionM64 } |
+  CSRInstruction { csrInstruction :: InstructionCSR } |
+  InvalidInstruction
   deriving (Eq, Read, Show)
 
 -- ================================================================
-
-data ByExtInstructionMapper t = ByExtInstructionMapper {
-  map_Invalid :: Instruction -> t,
-  map_I :: Instruction -> t,
-  map_M :: Instruction -> t,
-  map_I64 :: Instruction -> t,
-  map_M64 :: Instruction -> t,
-  map_CSR :: Instruction -> t
-}
-
-applyByExtInstructionMapper :: ByExtInstructionMapper t -> Instruction -> t
-applyByExtInstructionMapper m inst = case inst of
-  InvalidInstruction {} -> map_Invalid m inst
-
-  Lb {} -> map_I m inst
-  Lh {} -> map_I m inst
-  Lw {} -> map_I m inst
-  Ld {} -> map_I64 m inst
-  Lbu {} -> map_I m inst
-  Lhu {} -> map_I m inst
-  Lwu {} -> map_I64 m inst
-
-  Fence {} -> map_I m inst
-  Fence_i {} -> map_I m inst
-
-  Addi {} -> map_I m inst
-  Slli {} -> map_I m inst
-  Slti {} -> map_I m inst
-  Sltiu {} -> map_I m inst
-  Xori {} -> map_I m inst
-  Ori {} -> map_I m inst
-  Andi {} -> map_I m inst
-  Srli {} -> map_I m inst
-  Srai {} -> map_I m inst
-
-  Auipc {} -> map_I m inst
-
-  Addiw {} -> map_I64 m inst
-  Slliw {} -> map_I64 m inst
-  Srliw {} -> map_I64 m inst
-  Sraiw {} -> map_I64 m inst
-
-  Sb {} -> map_I m inst
-  Sh {} -> map_I m inst
-  Sw {} -> map_I m inst
-  Sd {} -> map_I64 m inst
-  Add {} -> map_I m inst
-  Sub {} -> map_I m inst
-  Sll {} -> map_I m inst
-  Slt {} -> map_I m inst
-  Sltu {} -> map_I m inst
-  Xor {} -> map_I m inst
-  Srl {} -> map_I m inst
-  Sra {} -> map_I m inst
-  Or {} -> map_I m inst
-  And {} -> map_I m inst
-  Mul {} -> map_M m inst
-  Mulh {} -> map_M m inst
-  Mulhsu {} -> map_M m inst
-  Mulhu {} -> map_M m inst
-  Div {} -> map_M m inst
-  Divu {} -> map_M m inst
-  Rem {} -> map_M m inst
-  Remu {} -> map_M m inst
-
-  Lui {} -> map_I m inst
-
-  Addw {} -> map_I64 m inst
-  Subw {} -> map_I64 m inst
-  Sllw {} -> map_I64 m inst
-  Srlw {} -> map_I64 m inst
-  Sraw {} -> map_I64 m inst
-  Mulw {} -> map_M64 m inst
-  Divw {} -> map_M64 m inst
-  Divuw {} -> map_M64 m inst
-  Remw {} -> map_M64 m inst
-  Remuw {} -> map_M64 m inst
-
-  Beq {} -> map_I m inst
-  Bne {} -> map_I m inst
-  Blt {} -> map_I m inst
-  Bge {} -> map_I m inst
-  Bltu {} -> map_I m inst
-  Bgeu {} -> map_I m inst
-
-  Jalr {} -> map_I m inst
-
-  Jal {} -> map_I m inst
-
-  Ecall {} -> map_CSR m inst
-  Ebreak {} -> map_CSR m inst
-  Uret {} -> map_CSR m inst
-  Sret {} -> map_CSR m inst
-  Mret {} -> map_CSR m inst
-  Wfi {} -> map_CSR m inst
-  Sfence_vm {} -> map_CSR m inst
-
-  Csrrw {} -> map_CSR m inst
-  Csrrs {} -> map_CSR m inst
-  Csrrc {} -> map_CSR m inst
-  Csrrwi {} -> map_CSR m inst
-  Csrrsi {} -> map_CSR m inst
-  Csrrci {} -> map_CSR m inst
-
 
 data InstructionSet = RV32I | RV32IM | RV64I | RV64IM deriving (Eq, Show)
 
@@ -226,17 +153,6 @@ supportsM RV32I = False
 supportsM RV32IM = True
 supportsM RV64I = False
 supportsM RV64IM = True
-
-instructionSetFilter :: InstructionSet -> Instruction -> Instruction
-instructionSetFilter iset = applyByExtInstructionMapper $ ByExtInstructionMapper {
-  map_Invalid = id,
-  map_I = id,
-  map_M = \inst -> if supportsM iset then inst else InvalidInstruction,
-  map_I64 = id,
-  map_M64 = \inst -> if supportsM iset then inst else InvalidInstruction,
-  map_CSR = id
-}
-
 
 -- ================================================================
 
@@ -297,11 +213,7 @@ funct3_SRAI  :: MachineInt;    funct3_SRAI  = 0x5      -- 3'b_101
 funct3_ORI   :: MachineInt;    funct3_ORI   = 0x6      -- 3'b_110
 funct3_ANDI  :: MachineInt;    funct3_ANDI  = 0x7      -- 3'b_111
 
--- OP_IMM.SLLI/SRLI/SRAI for RV32
-funct7_SLLI  :: MachineInt;    funct7_SLLI  = 0x00     -- 7'b_0000000
-funct7_SRLI  :: MachineInt;    funct7_SRLI  = 0x00     -- 7'b_0000000
-funct7_SRAI  :: MachineInt;    funct7_SRAI  = 0x20     -- 7'b_0100000
--- OP_IMM.SLLI/SRLI/SRAI for RV64
+-- OP_IMM.SLLI/SRLI/SRAI
 funct6_SLLI  :: MachineInt;    funct6_SLLI  = 0x00     -- 6'b_000000
 funct6_SRLI  :: MachineInt;    funct6_SRLI  = 0x00     -- 6'b_000000
 funct6_SRAI  :: MachineInt;    funct6_SRAI  = 0x10     -- 6'b_010000
@@ -451,14 +363,31 @@ signExtend l n = if testBit n (l-1)
                  then n-2^l
                  else n
 
+
 -- ================================================================
 -- The main decoder function
--- TODO: 1st arg should be MISA bits, instead of xlen, and more filters need to be added per MISA bits
 
 decode :: InstructionSet -> MachineInt -> Instruction
-decode iset inst = instructionSetFilter iset (decode_sub opcode)
+decode iset inst = case results of
+    [singleResult] -> singleResult         -- this case is the "normal" case
+    [] -> InvalidInstruction               -- this case is also part of the spec
+    _ -> error "ambiguous decoding result" -- this case means there's a bug in the spec
+
   where
-    xlen = bitwidth iset
+    results :: [Instruction]
+    results =
+      resultI ++
+      (if supportsM iset then resultM else []) ++
+      (if bitwidth iset == 64 then resultI64 else []) ++
+      (if bitwidth iset == 64 && supportsM iset then resultM64 else []) ++
+      resultCSR
+
+    resultI   = if decodeI   == InvalidI   then [] else [IInstruction   decodeI  ]
+    resultM   = if decodeM   == InvalidM   then [] else [MInstruction   decodeM  ]
+    resultI64 = if decodeI64 == InvalidI64 then [] else [I64Instruction decodeI64]
+    resultM64 = if decodeM64 == InvalidM64 then [] else [M64Instruction decodeM64]
+    resultCSR = if decodeCSR == InvalidCSR then [] else [CSRInstruction decodeCSR]
+
     -- Symbolic names for notable bitfields in the 32b instruction 'inst'
     -- Note: 'bitSlice x i j' is, roughly, Verilog's 'x [j-1, i]'
     opcode  = bitSlice inst 0 7        -- = Verilog's: inst [6:0]
@@ -496,13 +425,15 @@ decode iset inst = instructionSetFilter iset (decode_sub opcode)
                                 shift (bitSlice inst 8 12) 1  .|.
                                 shift (bitSlice inst 7 8) 11)
 
-    shamt5  = bitSlice inst 20 25    -- for RV32 SLLI, SRLI, SRAI
-    shamt6  = bitSlice inst 20 26    -- for RV64 SLLI, SRLI, SRAI
-    funct6  = bitSlice inst 26 32    -- for RV64 SLLI, SRLI, SRAI
+    shamt5  = bitSlice inst 20 25
+    shamt6  = bitSlice inst 20 26
+    shamtHi = bitSlice inst 25 26
+    funct6  = bitSlice inst 26 32
+    shamtHiTest = shamtHi == 0 || bitwidth iset == 64
 
     zimm    = bitSlice inst 15 20    -- for CSRRxI
 
-    decode_sub opcode
+    decodeI
       | opcode==opcode_LOAD, funct3==funct3_LB  = Lb  {rd=rd, rs1=rs1, oimm12=oimm12}
       | opcode==opcode_LOAD, funct3==funct3_LH  = Lh  {rd=rd, rs1=rs1, oimm12=oimm12}
       | opcode==opcode_LOAD, funct3==funct3_LW  = Lw  {rd=rd, rs1=rs1, oimm12=oimm12}
@@ -512,15 +443,16 @@ decode iset inst = instructionSetFilter iset (decode_sub opcode)
       | opcode==opcode_MISC_MEM, rd==0, funct3==funct3_FENCE,   rs1==0, msb4==0  = Fence {Decode.pred=pred, Decode.succ=succ}
       | opcode==opcode_MISC_MEM, rd==0, funct3==funct3_FENCE_I, rs1==0, imm12==0 = Fence_i
 
-      | opcode==opcode_OP_IMM, funct3==funct3_ADDI                                = Addi  {rd=rd, rs1=rs1, imm12=imm12}
-      | opcode==opcode_OP_IMM, funct3==funct3_SLLI, funct7==funct7_SLLI, xlen==32 = Slli  {rd=rd, rs1=rs1, shamt6=shamt5}
-      | opcode==opcode_OP_IMM, funct3==funct3_SLTI                                = Slti  {rd=rd, rs1=rs1, imm12=imm12}
-      | opcode==opcode_OP_IMM, funct3==funct3_SLTIU                               = Sltiu {rd=rd, rs1=rs1, imm12=imm12}
-      | opcode==opcode_OP_IMM, funct3==funct3_XORI                                = Xori  {rd=rd, rs1=rs1, imm12=imm12}
-      | opcode==opcode_OP_IMM, funct3==funct3_ORI                                 = Ori   {rd=rd, rs1=rs1, imm12=imm12}
-      | opcode==opcode_OP_IMM, funct3==funct3_ANDI                                = Andi  {rd=rd, rs1=rs1, imm12=imm12}
-      | opcode==opcode_OP_IMM, funct3==funct3_SRLI, funct7==funct7_SRLI, xlen==32 = Srli  {rd=rd, rs1=rs1, shamt6=shamt5}
-      | opcode==opcode_OP_IMM, funct3==funct3_SRAI, funct7==funct7_SRAI, xlen==32 = Srai  {rd=rd, rs1=rs1, shamt6=shamt5}
+      | opcode==opcode_OP_IMM, funct3==funct3_ADDI  = Addi  {rd=rd, rs1=rs1, imm12=imm12}
+      | opcode==opcode_OP_IMM, funct3==funct3_SLTI  = Slti  {rd=rd, rs1=rs1, imm12=imm12}
+      | opcode==opcode_OP_IMM, funct3==funct3_SLTIU = Sltiu {rd=rd, rs1=rs1, imm12=imm12}
+      | opcode==opcode_OP_IMM, funct3==funct3_XORI  = Xori  {rd=rd, rs1=rs1, imm12=imm12}
+      | opcode==opcode_OP_IMM, funct3==funct3_ORI   = Ori   {rd=rd, rs1=rs1, imm12=imm12}
+      | opcode==opcode_OP_IMM, funct3==funct3_ANDI  = Andi  {rd=rd, rs1=rs1, imm12=imm12}
+
+      | opcode==opcode_OP_IMM, funct3==funct3_SLLI, funct6==funct6_SLLI, shamtHiTest = Slli {rd=rd, rs1=rs1, shamt6=shamt6}
+      | opcode==opcode_OP_IMM, funct3==funct3_SRLI, funct6==funct6_SRLI, shamtHiTest = Srli {rd=rd, rs1=rs1, shamt6=shamt6}
+      | opcode==opcode_OP_IMM, funct3==funct3_SRAI, funct6==funct6_SRAI, shamtHiTest = Srai {rd=rd, rs1=rs1, shamt6=shamt6}
 
       | opcode==opcode_AUIPC = Auipc {rd=rd, oimm20=oimm20}
 
@@ -539,15 +471,6 @@ decode iset inst = instructionSetFilter iset (decode_sub opcode)
       | opcode==opcode_OP, funct3==funct3_OR,   funct7==funct7_OR   = Or   {rd=rd, rs1=rs1, rs2=rs2}
       | opcode==opcode_OP, funct3==funct3_AND,  funct7==funct7_AND  = And  {rd=rd, rs1=rs1, rs2=rs2}
 
-      | opcode==opcode_OP, funct3==funct3_MUL,    funct7==funct7_MUL    = Mul    {rd=rd, rs1=rs1, rs2=rs2}
-      | opcode==opcode_OP, funct3==funct3_MULH,   funct7==funct7_MULH   = Mulh   {rd=rd, rs1=rs1, rs2=rs2}
-      | opcode==opcode_OP, funct3==funct3_MULHSU, funct7==funct7_MULHSU = Mulhsu {rd=rd, rs1=rs1, rs2=rs2}
-      | opcode==opcode_OP, funct3==funct3_MULHU,  funct7==funct7_MULHU  = Mulhu  {rd=rd, rs1=rs1, rs2=rs2}
-      | opcode==opcode_OP, funct3==funct3_DIV,    funct7==funct7_DIV    = Div    {rd=rd, rs1=rs1, rs2=rs2}
-      | opcode==opcode_OP, funct3==funct3_DIVU,   funct7==funct7_DIVU   = Divu   {rd=rd, rs1=rs1, rs2=rs2}
-      | opcode==opcode_OP, funct3==funct3_REM,    funct7==funct7_REM    = Rem    {rd=rd, rs1=rs1, rs2=rs2}
-      | opcode==opcode_OP, funct3==funct3_REMU,   funct7==funct7_REMU   = Remu   {rd=rd, rs1=rs1, rs2=rs2}
-
       | opcode==opcode_LUI = Lui {rd=rd, imm20=imm20}
 
       | opcode==opcode_BRANCH, funct3==funct3_BEQ  = Beq  {rs1=rs1, rs2=rs2, sbimm12=sbimm12}
@@ -558,52 +481,62 @@ decode iset inst = instructionSetFilter iset (decode_sub opcode)
       | opcode==opcode_BRANCH, funct3==funct3_BGEU = Bgeu {rs1=rs1, rs2=rs2, sbimm12=sbimm12}
 
       | opcode==opcode_JALR = Jalr {rd=rd, rs1=rs1, oimm12=oimm12}
-
       | opcode==opcode_JAL  = Jal {rd=rd, jimm20=jimm20}
 
+      | True = InvalidI
+
+    decodeM
+      | opcode==opcode_OP, funct3==funct3_MUL,    funct7==funct7_MUL    = Mul    {rd=rd, rs1=rs1, rs2=rs2}
+      | opcode==opcode_OP, funct3==funct3_MULH,   funct7==funct7_MULH   = Mulh   {rd=rd, rs1=rs1, rs2=rs2}
+      | opcode==opcode_OP, funct3==funct3_MULHSU, funct7==funct7_MULHSU = Mulhsu {rd=rd, rs1=rs1, rs2=rs2}
+      | opcode==opcode_OP, funct3==funct3_MULHU,  funct7==funct7_MULHU  = Mulhu  {rd=rd, rs1=rs1, rs2=rs2}
+      | opcode==opcode_OP, funct3==funct3_DIV,    funct7==funct7_DIV    = Div    {rd=rd, rs1=rs1, rs2=rs2}
+      | opcode==opcode_OP, funct3==funct3_DIVU,   funct7==funct7_DIVU   = Divu   {rd=rd, rs1=rs1, rs2=rs2}
+      | opcode==opcode_OP, funct3==funct3_REM,    funct7==funct7_REM    = Rem    {rd=rd, rs1=rs1, rs2=rs2}
+      | opcode==opcode_OP, funct3==funct3_REMU,   funct7==funct7_REMU   = Remu   {rd=rd, rs1=rs1, rs2=rs2}
+      | True = InvalidM
+
+    decodeI64
+      | opcode==opcode_LOAD, funct3==funct3_LD  = Ld  {rd=rd, rs1=rs1, oimm12=oimm12}
+      | opcode==opcode_LOAD, funct3==funct3_LWU = Lwu {rd=rd, rs1=rs1, oimm12=oimm12}
+
+      | opcode==opcode_OP_IMM_32, funct3==funct3_ADDIW                       = Addiw  {rd=rd, rs1=rs1, imm12=imm12}
+      | opcode==opcode_OP_IMM_32, funct3==funct3_SLLIW, funct7==funct7_SLLIW = Slliw  {rd=rd, rs1=rs1, shamt5=shamt5}
+      | opcode==opcode_OP_IMM_32, funct3==funct3_SRLIW, funct7==funct7_SRLIW = Srliw  {rd=rd, rs1=rs1, shamt5=shamt5}
+      | opcode==opcode_OP_IMM_32, funct3==funct3_SRAIW, funct7==funct7_SRAIW = Sraiw  {rd=rd, rs1=rs1, shamt5=shamt5}
+
+      | opcode==opcode_STORE, funct3==funct3_SD = Sd {rs1=rs1, rs2=rs2, simm12=simm12}
+
+      | opcode==opcode_OP_32, funct3==funct3_ADDW, funct7==funct7_ADDW = Addw  {rd=rd, rs1=rs1, rs2=rs2}
+      | opcode==opcode_OP_32, funct3==funct3_SUBW, funct7==funct7_SUBW = Subw  {rd=rd, rs1=rs1, rs2=rs2}
+      | opcode==opcode_OP_32, funct3==funct3_SLLW, funct7==funct7_SLLW = Sllw  {rd=rd, rs1=rs1, rs2=rs2}
+      | opcode==opcode_OP_32, funct3==funct3_SRLW, funct7==funct7_SRLW = Srlw  {rd=rd, rs1=rs1, rs2=rs2}
+      | opcode==opcode_OP_32, funct3==funct3_SRAW, funct7==funct7_SRAW = Sraw  {rd=rd, rs1=rs1, rs2=rs2}
+
+      | True = InvalidI64
+
+    decodeM64
+      | opcode==opcode_OP_32, funct3==funct3_MULW,  funct7==funct7_MULW  = Mulw  {rd=rd, rs1=rs1, rs2=rs2}
+      | opcode==opcode_OP_32, funct3==funct3_DIVW,  funct7==funct7_DIVW  = Divw  {rd=rd, rs1=rs1, rs2=rs2}
+      | opcode==opcode_OP_32, funct3==funct3_DIVUW, funct7==funct7_DIVUW = Divuw {rd=rd, rs1=rs1, rs2=rs2}
+      | opcode==opcode_OP_32, funct3==funct3_REMW,  funct7==funct7_REMW  = Remw  {rd=rd, rs1=rs1, rs2=rs2}
+      | opcode==opcode_OP_32, funct3==funct3_REMUW, funct7==funct7_REMUW = Remuw {rd=rd, rs1=rs1, rs2=rs2}
+      | True = InvalidM64
+
+    decodeCSR
       | opcode==opcode_SYSTEM, rd==0, funct3==funct3_PRIV, rs1==0, funct12==funct12_ECALL  = Ecall
       | opcode==opcode_SYSTEM, rd==0, funct3==funct3_PRIV, rs1==0, funct12==funct12_EBREAK = Ebreak
       | opcode==opcode_SYSTEM, rd==0, funct3==funct3_PRIV, rs1==0, funct12==funct12_URET   = Uret
       | opcode==opcode_SYSTEM, rd==0, funct3==funct3_PRIV, rs1==0, funct12==funct12_SRET   = Sret
       | opcode==opcode_SYSTEM, rd==0, funct3==funct3_PRIV, rs1==0, funct12==funct12_MRET   = Mret
       | opcode==opcode_SYSTEM, rd==0, funct3==funct3_PRIV, rs1==0, funct12==funct12_WFI    = Wfi
-
-      | opcode==opcode_SYSTEM, rd==0, funct3==funct3_PRIV, funct7==funct7_SFENCE_VM        = Sfence_vm {rs1=rs1, rs2=rs2}
-
       | opcode==opcode_SYSTEM, funct3==funct3_CSRRW  = Csrrw   {rd=rd, rs1=rs1,   csr12=csr12}
       | opcode==opcode_SYSTEM, funct3==funct3_CSRRS  = Csrrs   {rd=rd, rs1=rs1,   csr12=csr12}
       | opcode==opcode_SYSTEM, funct3==funct3_CSRRC  = Csrrc   {rd=rd, rs1=rs1,   csr12=csr12}
       | opcode==opcode_SYSTEM, funct3==funct3_CSRRWI = Csrrwi  {rd=rd, zimm=zimm, csr12=csr12}
       | opcode==opcode_SYSTEM, funct3==funct3_CSRRSI = Csrrsi  {rd=rd, zimm=zimm, csr12=csr12}
       | opcode==opcode_SYSTEM, funct3==funct3_CSRRCI = Csrrci  {rd=rd, zimm=zimm, csr12=csr12}
+      | True = InvalidCSR
 
-      -- The following are RV64 only
-      | opcode==opcode_LOAD, funct3==funct3_LD,  xlen==64 = Ld  {rd=rd, rs1=rs1, oimm12=oimm12}
-      | opcode==opcode_LOAD, funct3==funct3_LWU, xlen==64 = Lwu {rd=rd, rs1=rs1, oimm12=oimm12}
-
-      | opcode==opcode_OP_IMM, funct3==funct3_SLLI, funct6==funct6_SLLI, xlen==64 = Slli  {rd=rd, rs1=rs1, shamt6=shamt6}
-      | opcode==opcode_OP_IMM, funct3==funct3_SRLI, funct6==funct6_SRLI, xlen==64 = Srli  {rd=rd, rs1=rs1, shamt6=shamt6}
-      | opcode==opcode_OP_IMM, funct3==funct3_SRAI, funct6==funct6_SRAI, xlen==64 = Srai  {rd=rd, rs1=rs1, shamt6=shamt6}
-
-      | opcode==opcode_OP_IMM_32, funct3==funct3_ADDIW,                       xlen==64 = Addiw  {rd=rd, rs1=rs1, imm12=imm12}
-      | opcode==opcode_OP_IMM_32, funct3==funct3_SLLIW, funct7==funct7_SLLIW, xlen==64 = Slliw  {rd=rd, rs1=rs1, shamt5=shamt5}
-      | opcode==opcode_OP_IMM_32, funct3==funct3_SRLIW, funct7==funct7_SRLIW, xlen==64 = Srliw  {rd=rd, rs1=rs1, shamt5=shamt5}
-      | opcode==opcode_OP_IMM_32, funct3==funct3_SRAIW, funct7==funct7_SRAIW, xlen==64 = Sraiw  {rd=rd, rs1=rs1, shamt5=shamt5}
-
-      | opcode==opcode_STORE, funct3==funct3_SD, xlen==64 = Sd {rs1=rs1, rs2=rs2, simm12=simm12}
-
-      | opcode==opcode_OP_32, funct3==funct3_ADDW,  funct7==funct7_ADDW,  xlen==64 = Addw  {rd=rd, rs1=rs1, rs2=rs2}
-      | opcode==opcode_OP_32, funct3==funct3_SUBW,  funct7==funct7_SUBW,  xlen==64 = Subw  {rd=rd, rs1=rs1, rs2=rs2}
-      | opcode==opcode_OP_32, funct3==funct3_SLLW,  funct7==funct7_SLLW,  xlen==64 = Sllw  {rd=rd, rs1=rs1, rs2=rs2}
-      | opcode==opcode_OP_32, funct3==funct3_SRLW,  funct7==funct7_SRLW,  xlen==64 = Srlw  {rd=rd, rs1=rs1, rs2=rs2}
-      | opcode==opcode_OP_32, funct3==funct3_SRAW,  funct7==funct7_SRAW,  xlen==64 = Sraw  {rd=rd, rs1=rs1, rs2=rs2}
-
-      | opcode==opcode_OP_32, funct3==funct3_MULW,  funct7==funct7_MULW,  xlen==64 = Mulw  {rd=rd, rs1=rs1, rs2=rs2}
-      | opcode==opcode_OP_32, funct3==funct3_DIVW,  funct7==funct7_DIVW,  xlen==64 = Divw  {rd=rd, rs1=rs1, rs2=rs2}
-      | opcode==opcode_OP_32, funct3==funct3_DIVUW, funct7==funct7_DIVUW, xlen==64 = Divuw {rd=rd, rs1=rs1, rs2=rs2}
-      | opcode==opcode_OP_32, funct3==funct3_REMW,  funct7==funct7_REMW,  xlen==64 = Remw  {rd=rd, rs1=rs1, rs2=rs2}
-      | opcode==opcode_OP_32, funct3==funct3_REMUW, funct7==funct7_REMUW, xlen==64 = Remuw {rd=rd, rs1=rs1, rs2=rs2}
-
-      | True                      = InvalidInstruction
 
 -- ================================================================

--- a/src/Decode.hs
+++ b/src/Decode.hs
@@ -25,14 +25,14 @@ data InstructionI =
   Fence_i |
 
   Addi { rd :: Register, rs1 :: Register, imm12 :: MachineInt } |
-  Slli { rd :: Register, rs1 :: Register, shamt6 :: MachineInt } |
+  Slli { rd :: Register, rs1 :: Register, shamt6 :: Int } |
   Slti { rd :: Register, rs1 :: Register, imm12 :: MachineInt } |
   Sltiu { rd :: Register, rs1 :: Register, imm12 :: MachineInt } |
   Xori { rd :: Register, rs1 :: Register, imm12 :: MachineInt } |
   Ori { rd :: Register, rs1 :: Register, imm12 :: MachineInt } |
   Andi { rd :: Register, rs1 :: Register, imm12 :: MachineInt } |
-  Srli { rd :: Register, rs1 :: Register, shamt6 :: MachineInt } |
-  Srai { rd :: Register, rs1 :: Register, shamt6 :: MachineInt } |
+  Srli { rd :: Register, rs1 :: Register, shamt6 :: Int } |
+  Srai { rd :: Register, rs1 :: Register, shamt6 :: Int } |
 
   Auipc { rd :: Register, oimm20 :: MachineInt } |
 
@@ -85,9 +85,9 @@ data InstructionI64 =
   Lwu { rd :: Register, rs1 :: Register, oimm12 :: MachineInt } |
 
   Addiw { rd :: Register, rs1 :: Register, imm12 :: MachineInt } |
-  Slliw { rd :: Register, rs1 :: Register, shamt5 :: MachineInt } |
-  Srliw { rd :: Register, rs1 :: Register, shamt5 :: MachineInt } |
-  Sraiw { rd :: Register, rs1 :: Register, shamt5 :: MachineInt } |
+  Slliw { rd :: Register, rs1 :: Register, shamt5 :: Int } |
+  Srliw { rd :: Register, rs1 :: Register, shamt5 :: Int } |
+  Sraiw { rd :: Register, rs1 :: Register, shamt5 :: Int } |
 
   Sd { rs1 :: Register, rs2 :: Register, simm12 :: MachineInt } |
 
@@ -363,6 +363,8 @@ signExtend l n = if testBit n (l-1)
                  then n-2^l
                  else n
 
+machineIntToShamt :: MachineInt -> Int
+machineIntToShamt = fromIntegral
 
 -- ================================================================
 -- The main decoder function
@@ -425,8 +427,8 @@ decode iset inst = case results of
                                 shift (bitSlice inst 8 12) 1  .|.
                                 shift (bitSlice inst 7 8) 11)
 
-    shamt5  = bitSlice inst 20 25
-    shamt6  = bitSlice inst 20 26
+    shamt5  = machineIntToShamt (bitSlice inst 20 25)
+    shamt6  = machineIntToShamt (bitSlice inst 20 26)
     shamtHi = bitSlice inst 25 26
     funct6  = bitSlice inst 26 32
     shamtHiTest = shamtHi == 0 || bitwidth iset == 64

--- a/src/Execute.hs
+++ b/src/Execute.hs
@@ -10,13 +10,13 @@ import ExecuteCSR as CSR
 import Control.Monad
 import Control.Monad.Trans.Maybe
 
-executeInvalid :: (RiscvProgram p t, MonadPlus p) => Instruction -> p ()
+executeInvalid :: (RiscvProgram p t) => Instruction -> p ()
 executeInvalid InvalidInstruction = do
   raiseException 0 2
 --  cycles <- getCSRField Field.MCycle -- NOTE: should we count or not count an invalid instruction -> check later, if yes it should come before raiseException
 --  setCSRField Field.MCycle (cycles + 1)
 
-executeValid :: (RiscvProgram p t, MonadPlus p) => (Instruction -> p ()) -> Instruction -> p ()
+executeValid :: (RiscvProgram p t) => (Instruction -> p ()) -> Instruction -> p ()
 executeValid f inst = do
   f inst
   cycles <- getCSRField Field.MCycle
@@ -25,7 +25,7 @@ executeValid f inst = do
   setCSRField Field.MInstRet (instret + 1)
 
 -- Note: instructions belonging to unsupported extensions were already filtered out by the decoder
-execute :: (RiscvProgram p t, MonadPlus p) => Instruction -> p ()
+execute :: (RiscvProgram p t) => Instruction -> p ()
 execute = applyByExtInstructionMapper $ ByExtInstructionMapper {
   map_Invalid = executeInvalid,
   map_I = executeValid I.execute,

--- a/src/Execute.hs
+++ b/src/Execute.hs
@@ -7,30 +7,19 @@ import ExecuteI64 as I64
 import ExecuteM as M
 import ExecuteM64 as M64
 import ExecuteCSR as CSR
-import Control.Monad
-import Control.Monad.Trans.Maybe
 
-executeInvalid :: (RiscvProgram p t) => Instruction -> p ()
-executeInvalid InvalidInstruction = do
-  raiseException 0 2
---  cycles <- getCSRField Field.MCycle -- NOTE: should we count or not count an invalid instruction -> check later, if yes it should come before raiseException
---  setCSRField Field.MCycle (cycles + 1)
 
-executeValid :: (RiscvProgram p t) => (Instruction -> p ()) -> Instruction -> p ()
-executeValid f inst = do
-  f inst
+-- Note: instructions belonging to unsupported extensions were already filtered out by the decoder
+execute :: (RiscvProgram p t) => Instruction -> p ()
+execute inst = do
+  case inst of
+    IInstruction   i   -> I.execute   i
+    MInstruction   i   -> M.execute   i
+    I64Instruction i   -> I64.execute i
+    M64Instruction i   -> M64.execute i
+    CSRInstruction i   -> CSR.execute i
+    InvalidInstruction -> raiseException 0 2
   cycles <- getCSRField Field.MCycle
   setCSRField Field.MCycle (cycles + 1)
   instret <- getCSRField Field.MInstRet
   setCSRField Field.MInstRet (instret + 1)
-
--- Note: instructions belonging to unsupported extensions were already filtered out by the decoder
-execute :: (RiscvProgram p t) => Instruction -> p ()
-execute = applyByExtInstructionMapper $ ByExtInstructionMapper {
-  map_Invalid = executeInvalid,
-  map_I = executeValid I.execute,
-  map_M = executeValid M.execute,
-  map_I64 = executeValid I64.execute,
-  map_M64 = executeValid M64.execute,
-  map_CSR = executeValid CSR.execute
-}

--- a/src/Execute.hs
+++ b/src/Execute.hs
@@ -10,13 +10,19 @@ import ExecuteCSR as CSR
 import Control.Monad
 import Control.Monad.Trans.Maybe
 
-execute :: (RiscvProgram p t, MonadPlus p) => Instruction -> p ()
-execute InvalidInstruction = do
+data InstructionSet = RV64I | RV64IM
+
+isetToExecuteFuncs :: (RiscvProgram p t, MonadPlus p) => InstructionSet -> [Instruction -> p ()]
+isetToExecuteFuncs RV64I = [I.execute, I64.execute, CSR.execute]
+isetToExecuteFuncs RV64IM = [I.execute, I64.execute, M.execute, M64.execute, CSR.execute]
+
+execute :: (RiscvProgram p t, MonadPlus p) => InstructionSet -> Instruction -> p ()
+execute iset InvalidInstruction = do
   raiseException 0 2
 --  cycles <- getCSRField Field.MCycle -- NOTE: should we count or not count an invalid instruction -> check later, if yes it should come before raiseException
 --  setCSRField Field.MCycle (cycles + 1)
-execute inst = do
-  msum (map (\f -> f inst) [I.execute, I64.execute, M.execute, M64.execute, CSR.execute])
+execute iset inst = do
+  msum (map (\f -> f inst) (isetToExecuteFuncs iset))
   cycles <- getCSRField Field.MCycle
   setCSRField Field.MCycle (cycles + 1)
   instret <- getCSRField Field.MInstRet

--- a/src/ExecuteCSR.hs
+++ b/src/ExecuteCSR.hs
@@ -10,7 +10,7 @@ import Data.Bits
 import Control.Monad
 import Prelude
 
-execute :: forall p t. (RiscvProgram p t) => Instruction -> p ()
+execute :: forall p t. (RiscvProgram p t) => InstructionCSR -> p ()
 -- begin ast
 execute (Csrrw rd rs1 csr12) = do
   x <- getRegister rs1

--- a/src/ExecuteCSR.hs
+++ b/src/ExecuteCSR.hs
@@ -10,7 +10,7 @@ import Data.Bits
 import Control.Monad
 import Prelude
 
-execute :: forall p t. (RiscvProgram p t, MonadPlus p) => Instruction -> p ()
+execute :: forall p t. (RiscvProgram p t) => Instruction -> p ()
 -- begin ast
 execute (Csrrw rd rs1 csr12) = do
   x <- getRegister rs1
@@ -52,4 +52,4 @@ execute Mret = do
   mepc <- getCSRField Field.MEPC
   setPC ((fromIntegral:: MachineInt -> t) mepc)
 -- end ast
-execute _ = mzero
+execute inst = error $ "dispatch bug: " ++ show inst

--- a/src/ExecuteI.hs
+++ b/src/ExecuteI.hs
@@ -11,7 +11,7 @@ import Data.Word
 import Control.Monad
 import Prelude
 
-execute :: forall p t. (RiscvProgram p t, MonadPlus p) => Instruction -> p ()
+execute :: forall p t. (RiscvProgram p t) => Instruction -> p ()
 -- begin ast
 execute (Lui rd imm20) = do
   setRegister rd (fromImm imm20)
@@ -197,5 +197,5 @@ execute (And rd rs1 rs2) = do
   y <- getRegister rs2
   setRegister rd (x .&. y)
 -- end ast
-execute _ = mzero
+execute inst = error $ "dispatch bug: " ++ show inst
 -- TODO: Fence/Fence.i?

--- a/src/ExecuteI.hs
+++ b/src/ExecuteI.hs
@@ -149,13 +149,13 @@ execute (Andi rd rs1 imm12) = do
   setRegister rd (x .&. (fromImm imm12))
 execute (Slli rd rs1 shamt6) = do
   x <- getRegister rs1
-  setRegister rd (sll x (regToShamt (fromImm shamt6 :: t)))
+  setRegister rd (sll x shamt6)
 execute (Srli rd rs1 shamt6) = do
   x <- getRegister rs1
-  setRegister rd (srl x (regToShamt (fromImm shamt6 :: t)))
+  setRegister rd (srl x shamt6)
 execute (Srai rd rs1 shamt6) = do
   x <- getRegister rs1
-  setRegister rd (sra x (regToShamt (fromImm shamt6 :: t)))
+  setRegister rd (sra x shamt6)
 execute (Add rd rs1 rs2) = do
   x <- getRegister rs1
   y <- getRegister rs2

--- a/src/ExecuteI.hs
+++ b/src/ExecuteI.hs
@@ -11,7 +11,7 @@ import Data.Word
 import Control.Monad
 import Prelude
 
-execute :: forall p t. (RiscvProgram p t) => Instruction -> p ()
+execute :: forall p t. (RiscvProgram p t) => InstructionI -> p ()
 -- begin ast
 execute (Lui rd imm20) = do
   setRegister rd (fromImm imm20)

--- a/src/ExecuteI64.hs
+++ b/src/ExecuteI64.hs
@@ -30,13 +30,13 @@ execute (Addiw rd rs1 imm12) = do
   setRegister rd (s32 (x + fromImm imm12))
 execute (Slliw rd rs1 shamt5) = do
   x <- getRegister rs1
-  setRegister rd (s32 (sll x (regToShamt5 (fromImm shamt5 :: t))))
+  setRegister rd (s32 (sll x shamt5))
 execute (Srliw rd rs1 shamt5) = do
   x <- getRegister rs1
-  setRegister rd (s32 (srl (u32 x) (regToShamt5 (fromImm shamt5 :: t))))
+  setRegister rd (s32 (srl (u32 x) shamt5))
 execute (Sraiw rd rs1 shamt5) = do
   x <- getRegister rs1
-  setRegister rd (s32 (sra (s32 x) (regToShamt5 (fromImm shamt5 :: t))))
+  setRegister rd (s32 (sra (s32 x) shamt5))
 execute (Addw rd rs1 rs2) = do
   x <- getRegister rs1
   y <- getRegister rs2

--- a/src/ExecuteI64.hs
+++ b/src/ExecuteI64.hs
@@ -8,7 +8,7 @@ import Data.Bits
 import Data.Int
 import Control.Monad
 
-execute :: forall p t. (RiscvProgram p t, MonadPlus p) => Instruction -> p ()
+execute :: forall p t. (RiscvProgram p t) => Instruction -> p ()
 -- begin ast
 execute (Lwu rd rs1 oimm12) = do
   a <- getRegister rs1
@@ -58,4 +58,4 @@ execute (Sraw rd rs1 rs2) = do
   y <- getRegister rs2
   setRegister rd (s32 (sra (s32 x) (regToShamt5 y)))
 -- end ast
-execute _ = mzero
+execute _ = error "dispatch bug"

--- a/src/ExecuteI64.hs
+++ b/src/ExecuteI64.hs
@@ -8,7 +8,7 @@ import Data.Bits
 import Data.Int
 import Control.Monad
 
-execute :: forall p t. (RiscvProgram p t) => Instruction -> p ()
+execute :: forall p t. (RiscvProgram p t) => InstructionI64 -> p ()
 -- begin ast
 execute (Lwu rd rs1 oimm12) = do
   a <- getRegister rs1
@@ -58,4 +58,4 @@ execute (Sraw rd rs1 rs2) = do
   y <- getRegister rs2
   setRegister rd (s32 (sra (s32 x) (regToShamt5 y)))
 -- end ast
-execute _ = error "dispatch bug"
+execute inst = error $ "dispatch bug: " ++ show inst

--- a/src/ExecuteM.hs
+++ b/src/ExecuteM.hs
@@ -6,7 +6,7 @@ import Utility
 import Control.Monad
 import Prelude
 
-execute :: forall p t. (RiscvProgram p t) => Instruction -> p ()
+execute :: forall p t. (RiscvProgram p t) => InstructionM -> p ()
 -- begin ast
 execute (Mul rd rs1 rs2) = do
   x <- getRegister rs1

--- a/src/ExecuteM.hs
+++ b/src/ExecuteM.hs
@@ -6,7 +6,7 @@ import Utility
 import Control.Monad
 import Prelude
 
-execute :: forall p t. (RiscvProgram p t, MonadPlus p) => Instruction -> p ()
+execute :: forall p t. (RiscvProgram p t) => Instruction -> p ()
 -- begin ast
 execute (Mul rd rs1 rs2) = do
   x <- getRegister rs1
@@ -51,4 +51,4 @@ execute (Remu rd rs1 rs2) = do
         | otherwise = remu x y
     in setRegister rd r
 -- end ast
-execute _ = mzero
+execute inst = error $ "dispatch bug: " ++ show inst

--- a/src/ExecuteM64.hs
+++ b/src/ExecuteM64.hs
@@ -5,7 +5,7 @@ import Program
 import Utility
 import Control.Monad
 
-execute :: forall p t. (RiscvProgram p t) => Instruction -> p ()
+execute :: forall p t. (RiscvProgram p t) => InstructionM64 -> p ()
 -- begin ast
 execute (Mulw rd rs1 rs2) = do
   x <- getRegister rs1

--- a/src/ExecuteM64.hs
+++ b/src/ExecuteM64.hs
@@ -5,7 +5,7 @@ import Program
 import Utility
 import Control.Monad
 
-execute :: forall p t. (RiscvProgram p t, MonadPlus p) => Instruction -> p ()
+execute :: forall p t. (RiscvProgram p t) => Instruction -> p ()
 -- begin ast
 execute (Mulw rd rs1 rs2) = do
   x <- getRegister rs1
@@ -38,4 +38,4 @@ execute (Remuw rd rs1 rs2) = do
         | otherwise = remu x y
     in setRegister rd (s32 r)
 -- end ast
-execute _ = mzero
+execute inst = error $ "dispatch bug: " ++ show inst

--- a/src/Run.hs
+++ b/src/Run.hs
@@ -80,7 +80,7 @@ helper maybeToHostAddress = do
           else do
           setPC (pc + 4)
           size <- getXLEN
-          execute (decode size $ (fromIntegral :: Int32 -> MachineInt) inst)
+          execute RV64IM (decode size $ (fromIntegral :: Int32 -> MachineInt) inst)
           interrupt <- liftIO checkInterrupt
           when interrupt $ do
             -- Signal interrupt by setting MEIP high.

--- a/src/Run.hs
+++ b/src/Run.hs
@@ -79,8 +79,7 @@ helper maybeToHostAddress = do
           getRegister 10
           else do
           setPC (pc + 4)
-          size <- getXLEN
-          execute RV64IM (decode size $ (fromIntegral :: Int32 -> MachineInt) inst)
+          execute (decode RV64IM $ (fromIntegral :: Int32 -> MachineInt) inst)
           interrupt <- liftIO checkInterrupt
           when interrupt $ do
             -- Signal interrupt by setting MEIP high.

--- a/src/Run32.hs
+++ b/src/Run32.hs
@@ -74,7 +74,7 @@ helper maybeToHostAddress = do
         setPC (pc + 4)
         pc <- getPC
         size <- getXLEN
-        execute (decode size $ (fromIntegral:: Int32 -> MachineInt) inst)
+        execute RV64IM (decode size $ (fromIntegral:: Int32 -> MachineInt) inst)
         interrupt <- liftIO checkInterrupt
         if interrupt then do
           -- Signal interrupt by setting MEIP high.

--- a/src/Run32.hs
+++ b/src/Run32.hs
@@ -73,8 +73,7 @@ helper maybeToHostAddress = do
         else do
         setPC (pc + 4)
         pc <- getPC
-        size <- getXLEN
-        execute RV64IM (decode size $ (fromIntegral:: Int32 -> MachineInt) inst)
+        execute (decode RV32IM $ (fromIntegral:: Int32 -> MachineInt) inst)
         interrupt <- liftIO checkInterrupt
         if interrupt then do
           -- Signal interrupt by setting MEIP high.

--- a/src/Test.hs
+++ b/src/Test.hs
@@ -64,8 +64,7 @@ helper iset maybeToHostAddress = do
           getRegister 10
           else do
           setPC (pc + 4)
-          size <- getXLEN
-          execute iset (decode size $ (fromIntegral :: Int32 -> MachineInt) inst)
+          execute (decode iset $ (fromIntegral :: Int32 -> MachineInt) inst)
           endCycle
       case result of
         Nothing -> step >> helper iset maybeToHostAddress

--- a/src/Test.hs
+++ b/src/Test.hs
@@ -29,7 +29,7 @@ tests :: [Test]
 tests = [Test "add" RV64I ""  11 "",
          Test "ebreak" RV64IM "" 0 "D\n?\n",
          Test "mul_support" RV64IM "" 0 "A\n",
-         Test "mul_support" RV64I  "" 0 "c\nB\n",
+         Test "mul_support" RV64I  "" 0 "cA\n",
          Test "sub" RV64I ""   7 "",
          Test "mul" RV64IM ""  42 "",
          Test "and" RV64I ""  35 "",

--- a/src/Test.hs
+++ b/src/Test.hs
@@ -26,13 +26,15 @@ runTest (Test name iset input returnValue output) = do
 
 -- TODO: Read this from a file.
 tests :: [Test]
-tests = [Test "add" RV64IM ""  11 "",
+tests = [Test "add" RV64I ""  11 "",
          Test "ebreak" RV64IM "" 0 "D\n?\n",
-         Test "sub" RV64IM ""   7 "",
+         Test "mul_support" RV64IM "" 0 "A\n",
+         Test "mul_support" RV64I  "" 0 "c\nB\n",
+         Test "sub" RV64I ""   7 "",
          Test "mul" RV64IM ""  42 "",
-         Test "and" RV64IM ""  35 "",
+         Test "and" RV64I ""  35 "",
          Test "or"  RV64IM "" 111 "",
-         Test "xor" RV64IM ""  76 "",
+         Test "xor" RV64I ""  76 "",
          Test "csr" RV64IM ""  29 "",
          Test "hello" RV64IM "" 0 "Hello, world!\n",
          Test "reverse" RV64IM "asdf" 0 "fdsa\n",

--- a/src/Test.hs
+++ b/src/Test.hs
@@ -15,34 +15,34 @@ import Program
 import Utility
 import VirtualMemory
 
-data Test = Test { name :: String, input :: String, returnValue :: Int64, output :: String }
+data Test = Test { name :: String, instructionSet :: InstructionSet, input :: String, returnValue :: Int64, output :: String }
 
 runTest :: Test -> IO Bool
-runTest (Test name input returnValue output) = do
-  result <- runFile ("test/build/" ++ name ++ "64") input
+runTest (Test name iset input returnValue output) = do
+  result <- runFile iset ("test/build/" ++ name ++ "64") input
   let isSuccess = (result == (returnValue, output))
   when (not isSuccess) (putStrLn ("Running " ++ name ++ " gave output " ++ show result ++ " but expected " ++ show (returnValue, output)))
   return $ isSuccess
 
 -- TODO: Read this from a file.
 tests :: [Test]
-tests = [Test "add" ""  11 "",
-         Test "ebreak" "" 0 "D\n?\n",
-         Test "sub" ""   7 "",
-         Test "mul" ""  42 "",
-         Test "and" ""  35 "",
-         Test "or"  "" 111 "",
-         Test "xor" ""  76 "",
-         Test "csr" ""  29 "",
-         Test "hello" "" 0 "Hello, world!\n",
-         Test "reverse" "asdf" 0 "fdsa\n",
-         Test "thuemorse" "" 0 "01101001100101101001011001101001100101100110100101101001100101101001011001101001011010011001011001101001100101101001011001101001\n",
-         Test "illegal" "" 0 "!\n?\n",
-         Test "time" "" 0 "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\n!\n.\n"]
+tests = [Test "add" RV64IM ""  11 "",
+         Test "ebreak" RV64IM "" 0 "D\n?\n",
+         Test "sub" RV64IM ""   7 "",
+         Test "mul" RV64IM ""  42 "",
+         Test "and" RV64IM ""  35 "",
+         Test "or"  RV64IM "" 111 "",
+         Test "xor" RV64IM ""  76 "",
+         Test "csr" RV64IM ""  29 "",
+         Test "hello" RV64IM "" 0 "Hello, world!\n",
+         Test "reverse" RV64IM "asdf" 0 "fdsa\n",
+         Test "thuemorse" RV64IM "" 0 "01101001100101101001011001101001100101100110100101101001100101101001011001101001011010011001011001101001100101101001011001101001\n",
+         Test "illegal" RV64IM "" 0 "!\n?\n",
+         Test "time" RV64IM "" 0 "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\n!\n.\n"]
 
 -- TODO: Reduce code duplication with Run.
-helper :: Maybe Int64 -> BufferState Minimal64 Int64
-helper maybeToHostAddress = do
+helper :: InstructionSet -> Maybe Int64 -> BufferState Minimal64 Int64
+helper iset maybeToHostAddress = do
   toHostValue <- case maybeToHostAddress of
     Nothing -> return 0 -- default value
     Just toHostAddress -> loadWord toHostAddress
@@ -63,22 +63,22 @@ helper maybeToHostAddress = do
           else do
           setPC (pc + 4)
           size <- getXLEN
-          execute (decode size $ (fromIntegral :: Int32 -> MachineInt) inst)
+          execute iset (decode size $ (fromIntegral :: Int32 -> MachineInt) inst)
           endCycle
       case result of
-        Nothing -> step >> helper maybeToHostAddress
+        Nothing -> step >> helper iset maybeToHostAddress
         Just r -> return r
 
-runProgram :: Maybe Int64 -> Minimal64 -> String -> (Int64, String)
-runProgram maybeToHostAddress comp input = (returnValue, output)
-  where ((returnValue, _), output) = runBufferIO (runStateT (helper maybeToHostAddress) comp) input
+runProgram :: InstructionSet -> Maybe Int64 -> Minimal64 -> String -> (Int64, String)
+runProgram iset maybeToHostAddress comp input = (returnValue, output)
+  where ((returnValue, _), output) = runBufferIO (runStateT (helper iset maybeToHostAddress) comp) input
 
-runFile :: String -> String -> IO (Int64, String)
-runFile f input = do
+runFile :: InstructionSet -> String -> String -> IO (Int64, String)
+runFile iset f input = do
   (maybeToHostAddress, mem) <- readProgram f
   let c = Minimal64 { registers = (take 31 $ repeat 0), csrs = (resetCSRFile 64), pc = 0x80000000, nextPC = 0,
                       mem = S.fromList mem } in
-    return $ runProgram maybeToHostAddress c input
+    return $ runProgram iset maybeToHostAddress c input
 
 main :: IO ()
 main = do

--- a/test/src/mul_support.c
+++ b/test/src/mul_support.c
@@ -1,0 +1,37 @@
+#include "../trap_handler.h"
+#include "../mmio.h"
+
+
+void trap_handler() {
+  // register char causechar asm ("x15");
+  // asm volatile("csrr x15,mcause");
+  register char causechar;
+  asm volatile("csrr %0,mcause" : "=r"(causechar));
+
+  causechar += 'a';
+  putchar(causechar);
+  putchar('\n');
+}
+
+int main() {
+  // register trap handler
+  asm volatile("csrrw zero,mtvec,%0" :: "r" (_trap_handler));
+
+  register char a = 5;
+  register char b = 13;
+  register char c = 'B';
+
+  // write mul in assembly to make sure the compiler doesn't
+  // constant propagate or do other stuff.
+  // mul causes exception if M extension not available
+  asm volatile("mul %0,%1,%2"
+	       : "=r"(c)           // output register
+	       : "r"(a), "r"(b));  // input registers
+
+  // runs in any case, but if mul was unavailable, it will print the
+  // old value 'B' instead of the new value 'A', and the trap handler
+  // will not have run before
+  putchar(c);
+  putchar('\n');
+  return 0;
+}

--- a/test/src/mul_support.c
+++ b/test/src/mul_support.c
@@ -1,6 +1,8 @@
 #include "../trap_handler.h"
 #include "../mmio.h"
 
+int trap_handler_ran = 0;
+char result = 0;
 
 void trap_handler() {
   // register char causechar asm ("x15");
@@ -10,7 +12,8 @@ void trap_handler() {
 
   causechar += 'a';
   putchar(causechar);
-  putchar('\n');
+  result = 65; // the trap handler is knows how to do the multiplication
+  trap_handler_ran = 1;
 }
 
 int main() {
@@ -19,7 +22,7 @@ int main() {
 
   register char a = 5;
   register char b = 13;
-  register char c = 'B';
+  register char c;
 
   // write mul in assembly to make sure the compiler doesn't
   // constant propagate or do other stuff.
@@ -28,10 +31,10 @@ int main() {
 	       : "=r"(c)           // output register
 	       : "r"(a), "r"(b));  // input registers
 
-  // runs in any case, but if mul was unavailable, it will print the
-  // old value 'B' instead of the new value 'A', and the trap handler
-  // will not have run before
-  putchar(c);
+  if (trap_handler_ran) {
+    c = result;
+  }
+  putchar(c); 
   putchar('\n');
   return 0;
 }


### PR DESCRIPTION
Here's a test case which tries to run an interrupt handler in case the M extension is not available.

The test fails, and I don't fully understand why. 

Observerd behavior: If the `mul` instruction is not available, its destination register is overwritten with 0, and no trap handler is run.

Expected behavior: If the `mul` instruction is not available, the destination register is left unmodified, and the trap handler is run.