### PR TITLE
Use binary literals

### DIFF
--- a/src/Decode.hs
+++ b/src/Decode.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE DuplicateRecordFields, BinaryLiterals #-}
 
 module Decode where
 
@@ -164,193 +164,193 @@ type Register = MachineInt
 -- Major opcode (instr [6:0]), see Table 19.1 in spec
 type Opcode = MachineInt
 
-opcode_LOAD      :: Opcode;    opcode_LOAD      = 0x03    -- 7'b_00_000_11
-opcode_LOAD_FP   :: Opcode;    opcode_LOAD_FP   = 0x07    -- 7'b_00_001_11
-opcode_MISC_MEM  :: Opcode;    opcode_MISC_MEM  = 0x0F    -- 7'b_00_011_11
-opcode_OP_IMM    :: Opcode;    opcode_OP_IMM    = 0x13    -- 7'b_00_100_11
-opcode_AUIPC     :: Opcode;    opcode_AUIPC     = 0x17    -- 7'b_00_101_11
-opcode_OP_IMM_32 :: Opcode;    opcode_OP_IMM_32 = 0x1B    -- 7'b_00_110_11
+opcode_LOAD      :: Opcode;    opcode_LOAD      = 0b0000011
+opcode_LOAD_FP   :: Opcode;    opcode_LOAD_FP   = 0b0000111
+opcode_MISC_MEM  :: Opcode;    opcode_MISC_MEM  = 0b0001111
+opcode_OP_IMM    :: Opcode;    opcode_OP_IMM    = 0b0010011
+opcode_AUIPC     :: Opcode;    opcode_AUIPC     = 0b0010111
+opcode_OP_IMM_32 :: Opcode;    opcode_OP_IMM_32 = 0b0011011
 
-opcode_STORE     :: Opcode;    opcode_STORE     = 0x23    -- 7'b_01_000_11
-opcode_STORE_FP  :: Opcode;    opcode_STORE_FP  = 0x27    -- 7'b_01_001_11
-opcode_AMO       :: Opcode;    opcode_AMO       = 0x2F    -- 7'b_01_011_11
-opcode_OP        :: Opcode;    opcode_OP        = 0x33    -- 7'b_01_100_11
-opcode_LUI       :: Opcode;    opcode_LUI       = 0x37    -- 7'b_01_101_11
-opcode_OP_32     :: Opcode;    opcode_OP_32     = 0x3B    -- 7'b_01_110_11
+opcode_STORE     :: Opcode;    opcode_STORE     = 0b0100011
+opcode_STORE_FP  :: Opcode;    opcode_STORE_FP  = 0b0100111
+opcode_AMO       :: Opcode;    opcode_AMO       = 0b0101111
+opcode_OP        :: Opcode;    opcode_OP        = 0b0110011
+opcode_LUI       :: Opcode;    opcode_LUI       = 0b0110111
+opcode_OP_32     :: Opcode;    opcode_OP_32     = 0b0111011
 
-opcode_MADD      :: Opcode;    opcode_MADD      = 0x43    -- 7'b_10_000_11
-opcode_MSUB      :: Opcode;    opcode_MSUB      = 0x47    -- 7'b_10_001_11
-opcode_NMSUB     :: Opcode;    opcode_NMSUB     = 0x4B    -- 7'b_10_010_11
-opcode_NMADD     :: Opcode;    opcode_NMADD     = 0x4F    -- 7'b_10_011_11
-opcode_OP_FP     :: Opcode;    opcode_OP_FP     = 0x53    -- 7'b_10_100_11
+opcode_MADD      :: Opcode;    opcode_MADD      = 0b1000011
+opcode_MSUB      :: Opcode;    opcode_MSUB      = 0b1000111
+opcode_NMSUB     :: Opcode;    opcode_NMSUB     = 0b1001011
+opcode_NMADD     :: Opcode;    opcode_NMADD     = 0b1001111
+opcode_OP_FP     :: Opcode;    opcode_OP_FP     = 0b1010011
 
-opcode_BRANCH    :: Opcode;    opcode_BRANCH    = 0x63    -- 7'b_11_000_11
-opcode_JALR      :: Opcode;    opcode_JALR      = 0x67    -- 7'b_11_001_11
-opcode_JAL       :: Opcode;    opcode_JAL       = 0x6F    -- 7'b_11_011_11
-opcode_SYSTEM    :: Opcode;    opcode_SYSTEM    = 0x73    -- 7'b_11_100_11
+opcode_BRANCH    :: Opcode;    opcode_BRANCH    = 0b1100011
+opcode_JALR      :: Opcode;    opcode_JALR      = 0b1100111
+opcode_JAL       :: Opcode;    opcode_JAL       = 0b1101111
+opcode_SYSTEM    :: Opcode;    opcode_SYSTEM    = 0b1110011
 
 -- LOAD sub-opcodes
-funct3_LB  :: MachineInt;    funct3_LB  = 0x0     -- 3'b_000
-funct3_LH  :: MachineInt;    funct3_LH  = 0x1     -- 3'b_001
-funct3_LW  :: MachineInt;    funct3_LW  = 0x2     -- 3'b_010
-funct3_LD  :: MachineInt;    funct3_LD  = 0x3     -- 3'b_011
-funct3_LBU :: MachineInt;    funct3_LBU = 0x4     -- 3'b_100
-funct3_LHU :: MachineInt;    funct3_LHU = 0x5     -- 3'b_101
-funct3_LWU :: MachineInt;    funct3_LWU = 0x6     -- 3'b_110
+funct3_LB  :: MachineInt;    funct3_LB  = 0b000
+funct3_LH  :: MachineInt;    funct3_LH  = 0b001
+funct3_LW  :: MachineInt;    funct3_LW  = 0b010
+funct3_LD  :: MachineInt;    funct3_LD  = 0b011
+funct3_LBU :: MachineInt;    funct3_LBU = 0b100
+funct3_LHU :: MachineInt;    funct3_LHU = 0b101
+funct3_LWU :: MachineInt;    funct3_LWU = 0b110
 
 -- MISC_MEM sub-opcodes
-funct3_FENCE   :: MachineInt;    funct3_FENCE   = 0x0      -- 3'b_000
-funct3_FENCE_I :: MachineInt;    funct3_FENCE_I = 0x1      -- 3'b_001
+funct3_FENCE   :: MachineInt;    funct3_FENCE   = 0b000
+funct3_FENCE_I :: MachineInt;    funct3_FENCE_I = 0b001
 
 -- OP_IMM sub-opcodes
-funct3_ADDI  :: MachineInt;    funct3_ADDI  = 0x0      -- 3'b_000
-funct3_SLLI  :: MachineInt;    funct3_SLLI  = 0x1      -- 3'b_001
-funct3_SLTI  :: MachineInt;    funct3_SLTI  = 0x2      -- 3'b_010
-funct3_SLTIU :: MachineInt;    funct3_SLTIU = 0x3      -- 3'b_011
-funct3_XORI  :: MachineInt;    funct3_XORI  = 0x4      -- 3'b_100
-funct3_SRLI  :: MachineInt;    funct3_SRLI  = 0x5      -- 3'b_101
-funct3_SRAI  :: MachineInt;    funct3_SRAI  = 0x5      -- 3'b_101
-funct3_ORI   :: MachineInt;    funct3_ORI   = 0x6      -- 3'b_110
-funct3_ANDI  :: MachineInt;    funct3_ANDI  = 0x7      -- 3'b_111
+funct3_ADDI  :: MachineInt;    funct3_ADDI  = 0b000
+funct3_SLLI  :: MachineInt;    funct3_SLLI  = 0b001
+funct3_SLTI  :: MachineInt;    funct3_SLTI  = 0b010
+funct3_SLTIU :: MachineInt;    funct3_SLTIU = 0b011
+funct3_XORI  :: MachineInt;    funct3_XORI  = 0b100
+funct3_SRLI  :: MachineInt;    funct3_SRLI  = 0b101
+funct3_SRAI  :: MachineInt;    funct3_SRAI  = 0b101
+funct3_ORI   :: MachineInt;    funct3_ORI   = 0b110
+funct3_ANDI  :: MachineInt;    funct3_ANDI  = 0b111
 
 -- OP_IMM.SLLI/SRLI/SRAI
-funct6_SLLI  :: MachineInt;    funct6_SLLI  = 0x00     -- 6'b_000000
-funct6_SRLI  :: MachineInt;    funct6_SRLI  = 0x00     -- 6'b_000000
-funct6_SRAI  :: MachineInt;    funct6_SRAI  = 0x10     -- 6'b_010000
+funct6_SLLI  :: MachineInt;    funct6_SLLI  = 0b000000
+funct6_SRLI  :: MachineInt;    funct6_SRLI  = 0b000000
+funct6_SRAI  :: MachineInt;    funct6_SRAI  = 0b010000
 
 -- OP_IMM_32 sub-opcodes (RV64 only)
-funct3_ADDIW :: MachineInt;    funct3_ADDIW = 0x0     -- 3'b_000
+funct3_ADDIW :: MachineInt;    funct3_ADDIW = 0b000
 
-funct3_SLLIW :: MachineInt;    funct3_SLLIW = 0x1     -- 3'b_001
-funct7_SLLIW :: MachineInt;    funct7_SLLIW = 0x00    -- 7'b_0000000
+funct3_SLLIW :: MachineInt;    funct3_SLLIW = 0b001
+funct7_SLLIW :: MachineInt;    funct7_SLLIW = 0b0000000
 
-funct3_SRLIW :: MachineInt;    funct3_SRLIW = 0x5     -- 3'b_101
-funct7_SRLIW :: MachineInt;    funct7_SRLIW = 0x00    -- 7'b_0000000
+funct3_SRLIW :: MachineInt;    funct3_SRLIW = 0b101
+funct7_SRLIW :: MachineInt;    funct7_SRLIW = 0b0000000
 
-funct3_SRAIW :: MachineInt;    funct3_SRAIW = 0x5     -- 3'b_101
-funct7_SRAIW :: MachineInt;    funct7_SRAIW = 0x20    -- 7'b_0100000
+funct3_SRAIW :: MachineInt;    funct3_SRAIW = 0b101
+funct7_SRAIW :: MachineInt;    funct7_SRAIW = 0b0100000
 
 -- STORE sub-opcodes
-funct3_SB :: MachineInt;    funct3_SB = 0x0     -- 3'b_000
-funct3_SH :: MachineInt;    funct3_SH = 0x1     -- 3'b_001
-funct3_SW :: MachineInt;    funct3_SW = 0x2     -- 3'b_010
-funct3_SD :: MachineInt;    funct3_SD = 0x3     -- 3'b_011
+funct3_SB :: MachineInt;    funct3_SB = 0b000
+funct3_SH :: MachineInt;    funct3_SH = 0b001
+funct3_SW :: MachineInt;    funct3_SW = 0b010
+funct3_SD :: MachineInt;    funct3_SD = 0b011
 
 -- OP sub-opcodes
-funct3_ADD  :: MachineInt;    funct3_ADD  = 0x0     -- 3'b_000
-funct7_ADD  :: MachineInt;    funct7_ADD  = 0x00    -- 7'b_000_0000
+funct3_ADD  :: MachineInt;    funct3_ADD  = 0b000
+funct7_ADD  :: MachineInt;    funct7_ADD  = 0b0000000
 
-funct3_SUB  :: MachineInt;    funct3_SUB  = 0x0     -- 3'b_000
-funct7_SUB  :: MachineInt;    funct7_SUB  = 0x20    -- 7'b_010_0000
+funct3_SUB  :: MachineInt;    funct3_SUB  = 0b000
+funct7_SUB  :: MachineInt;    funct7_SUB  = 0b0100000
 
-funct3_SLL  :: MachineInt;    funct3_SLL  = 0x1     -- 3'b_001
-funct7_SLL  :: MachineInt;    funct7_SLL  = 0x00    -- 7'b_000_0000
+funct3_SLL  :: MachineInt;    funct3_SLL  = 0b001
+funct7_SLL  :: MachineInt;    funct7_SLL  = 0b0000000
 
-funct3_SLT  :: MachineInt;    funct3_SLT  = 0x2     -- 3'b_010
-funct7_SLT  :: MachineInt;    funct7_SLT  = 0x00    -- 7'b_000_0000
+funct3_SLT  :: MachineInt;    funct3_SLT  = 0b010
+funct7_SLT  :: MachineInt;    funct7_SLT  = 0b0000000
 
-funct3_SLTU :: MachineInt;    funct3_SLTU = 0x3     -- 3'b_011
-funct7_SLTU :: MachineInt;    funct7_SLTU = 0x00    -- 7'b_000_0000
+funct3_SLTU :: MachineInt;    funct3_SLTU = 0b011
+funct7_SLTU :: MachineInt;    funct7_SLTU = 0b0000000
 
-funct3_XOR  :: MachineInt;    funct3_XOR  = 0x4     -- 3'b_100
-funct7_XOR  :: MachineInt;    funct7_XOR  = 0x00    -- 7'b_000_0000
+funct3_XOR  :: MachineInt;    funct3_XOR  = 0b100
+funct7_XOR  :: MachineInt;    funct7_XOR  = 0b0000000
 
-funct3_SRL  :: MachineInt;    funct3_SRL  = 0x5     -- 3'b_101
-funct7_SRL  :: MachineInt;    funct7_SRL  = 0x00    -- 7'b_000_0000
+funct3_SRL  :: MachineInt;    funct3_SRL  = 0b101
+funct7_SRL  :: MachineInt;    funct7_SRL  = 0b0000000
 
-funct3_SRA  :: MachineInt;    funct3_SRA  = 0x5     -- 3'b_101
-funct7_SRA  :: MachineInt;    funct7_SRA  = 0x20    -- 7'b_010_0000
+funct3_SRA  :: MachineInt;    funct3_SRA  = 0b101
+funct7_SRA  :: MachineInt;    funct7_SRA  = 0b0100000
 
-funct3_OR   :: MachineInt;    funct3_OR   = 0x6     -- 3'b_110
-funct7_OR   :: MachineInt;    funct7_OR   = 0x00    -- 7'b_000_0000
+funct3_OR   :: MachineInt;    funct3_OR   = 0b110
+funct7_OR   :: MachineInt;    funct7_OR   = 0b0000000
 
-funct3_AND  :: MachineInt;    funct3_AND  = 0x7     -- 3'b_111
-funct7_AND  :: MachineInt;    funct7_AND  = 0x00    -- 7'b_000_0000
+funct3_AND  :: MachineInt;    funct3_AND  = 0b111
+funct7_AND  :: MachineInt;    funct7_AND  = 0b0000000
 
 -- OP sub-opcodes, M standard extension
 
-funct3_MUL    :: MachineInt;    funct3_MUL    = 0x0     -- 3'b_000
-funct7_MUL    :: MachineInt;    funct7_MUL    = 0x01    -- 7'b_000_0001
+funct3_MUL    :: MachineInt;    funct3_MUL    = 0b000
+funct7_MUL    :: MachineInt;    funct7_MUL    = 0b0000001
 
-funct3_MULH   :: MachineInt;    funct3_MULH   = 0x1     -- 3'b_001
-funct7_MULH   :: MachineInt;    funct7_MULH   = 0x01    -- 7'b_000_0001
+funct3_MULH   :: MachineInt;    funct3_MULH   = 0b001
+funct7_MULH   :: MachineInt;    funct7_MULH   = 0b0000001
 
-funct3_MULHSU :: MachineInt;    funct3_MULHSU = 0x2     -- 3'b_010
-funct7_MULHSU :: MachineInt;    funct7_MULHSU = 0x01    -- 7'b_000_0001
+funct3_MULHSU :: MachineInt;    funct3_MULHSU = 0b010
+funct7_MULHSU :: MachineInt;    funct7_MULHSU = 0b0000001
 
-funct3_MULHU  :: MachineInt;    funct3_MULHU  = 0x3     -- 3'b_011
-funct7_MULHU  :: MachineInt;    funct7_MULHU  = 0x01    -- 7'b_000_0001
+funct3_MULHU  :: MachineInt;    funct3_MULHU  = 0b011
+funct7_MULHU  :: MachineInt;    funct7_MULHU  = 0b0000001
 
-funct3_DIV    :: MachineInt;    funct3_DIV    = 0x4     -- 3'b_100
-funct7_DIV    :: MachineInt;    funct7_DIV    = 0x01    -- 7'b_000_0001
+funct3_DIV    :: MachineInt;    funct3_DIV    = 0b100
+funct7_DIV    :: MachineInt;    funct7_DIV    = 0b0000001
 
-funct3_DIVU   :: MachineInt;    funct3_DIVU   = 0x5     -- 3'b_101
-funct7_DIVU   :: MachineInt;    funct7_DIVU   = 0x01    -- 7'b_000_0001
+funct3_DIVU   :: MachineInt;    funct3_DIVU   = 0b101
+funct7_DIVU   :: MachineInt;    funct7_DIVU   = 0b0000001
 
-funct3_REM    :: MachineInt;    funct3_REM    = 0x6     -- 3'b_110
-funct7_REM    :: MachineInt;    funct7_REM    = 0x01    -- 7'b_000_0001
+funct3_REM    :: MachineInt;    funct3_REM    = 0b110
+funct7_REM    :: MachineInt;    funct7_REM    = 0b0000001
 
-funct3_REMU   :: MachineInt;    funct3_REMU   = 0x7     -- 3'b_111
-funct7_REMU   :: MachineInt;    funct7_REMU   = 0x01    -- 7'b_000_0001
+funct3_REMU   :: MachineInt;    funct3_REMU   = 0b111
+funct7_REMU   :: MachineInt;    funct7_REMU   = 0b0000001
 
 -- OP_32 sub-opcodes (RV64 only)
-funct3_ADDW  :: MachineInt;    funct3_ADDW  = 0x0     --- 3'b_000
-funct7_ADDW  :: MachineInt;    funct7_ADDW  = 0x00    --- 7'b_000_0000
+funct3_ADDW  :: MachineInt;    funct3_ADDW  = 0b000
+funct7_ADDW  :: MachineInt;    funct7_ADDW  = 0b0000000
 
-funct3_SUBW  :: MachineInt;    funct3_SUBW  = 0x0     --- 3'b_000
-funct7_SUBW  :: MachineInt;    funct7_SUBW  = 0x20    --- 7'b_010_0000
+funct3_SUBW  :: MachineInt;    funct3_SUBW  = 0b000
+funct7_SUBW  :: MachineInt;    funct7_SUBW  = 0b0100000
 
-funct3_SLLW  :: MachineInt;    funct3_SLLW  = 0x1     --- 3'b_001
-funct7_SLLW  :: MachineInt;    funct7_SLLW  = 0x00    --- 7'b_000_0000
+funct3_SLLW  :: MachineInt;    funct3_SLLW  = 0b001
+funct7_SLLW  :: MachineInt;    funct7_SLLW  = 0b0000000
 
-funct3_SRLW  :: MachineInt;    funct3_SRLW  = 0x5     --- 3'b_101
-funct7_SRLW  :: MachineInt;    funct7_SRLW  = 0x00    --- 7'b_000_0000
+funct3_SRLW  :: MachineInt;    funct3_SRLW  = 0b101
+funct7_SRLW  :: MachineInt;    funct7_SRLW  = 0b0000000
 
-funct3_SRAW  :: MachineInt;    funct3_SRAW  = 0x5     --- 3'b_101
-funct7_SRAW  :: MachineInt;    funct7_SRAW  = 0x20    --- 7'b_010_0000
+funct3_SRAW  :: MachineInt;    funct3_SRAW  = 0b101
+funct7_SRAW  :: MachineInt;    funct7_SRAW  = 0b0100000
 
 -- OP_32 sub-opcodes, M standard extension (RV64 only)
-funct3_MULW  :: MachineInt;    funct3_MULW  = 0x0     --- 3'b_000
-funct7_MULW  :: MachineInt;    funct7_MULW  = 0x01    --- 7'b_000_0001
+funct3_MULW  :: MachineInt;    funct3_MULW  = 0b000
+funct7_MULW  :: MachineInt;    funct7_MULW  = 0b0000001
 
-funct3_DIVW  :: MachineInt;    funct3_DIVW  = 0x4     --- 3'b_100
-funct7_DIVW  :: MachineInt;    funct7_DIVW  = 0x01    --- 7'b_000_0001
+funct3_DIVW  :: MachineInt;    funct3_DIVW  = 0b100
+funct7_DIVW  :: MachineInt;    funct7_DIVW  = 0b0000001
 
-funct3_DIVUW :: MachineInt;    funct3_DIVUW = 0x5     --- 3'b_101
-funct7_DIVUW :: MachineInt;    funct7_DIVUW = 0x01    --- 7'b_000_0001
+funct3_DIVUW :: MachineInt;    funct3_DIVUW = 0b101
+funct7_DIVUW :: MachineInt;    funct7_DIVUW = 0b0000001
 
-funct3_REMW  :: MachineInt;    funct3_REMW  = 0x6     --- 3'b_110
-funct7_REMW  :: MachineInt;    funct7_REMW  = 0x01    --- 7'b_000_0001
+funct3_REMW  :: MachineInt;    funct3_REMW  = 0b110
+funct7_REMW  :: MachineInt;    funct7_REMW  = 0b0000001
 
-funct3_REMUW :: MachineInt;    funct3_REMUW = 0x7     --- 3'b_111
-funct7_REMUW :: MachineInt;    funct7_REMUW = 0x01    --- 7'b_000_0001
+funct3_REMUW :: MachineInt;    funct3_REMUW = 0b111
+funct7_REMUW :: MachineInt;    funct7_REMUW = 0b0000001
 
 -- BRANCH sub-opcodes
-funct3_BEQ  :: MachineInt;    funct3_BEQ  = 0x0     -- 3'b_000
-funct3_BNE  :: MachineInt;    funct3_BNE  = 0x1     -- 3'b_001
-funct3_BLT  :: MachineInt;    funct3_BLT  = 0x4     -- 3'b_100
-funct3_BGE  :: MachineInt;    funct3_BGE  = 0x5     -- 3'b_101
-funct3_BLTU :: MachineInt;    funct3_BLTU = 0x6     -- 3'b_110
-funct3_BGEU :: MachineInt;    funct3_BGEU = 0x7     -- 3'b_111
+funct3_BEQ  :: MachineInt;    funct3_BEQ  = 0b000
+funct3_BNE  :: MachineInt;    funct3_BNE  = 0b001
+funct3_BLT  :: MachineInt;    funct3_BLT  = 0b100
+funct3_BGE  :: MachineInt;    funct3_BGE  = 0b101
+funct3_BLTU :: MachineInt;    funct3_BLTU = 0b110
+funct3_BGEU :: MachineInt;    funct3_BGEU = 0b111
 
 -- SYSTEM sub-opcodes
-funct3_PRIV   :: MachineInt;    funct3_PRIV   = 0x0     -- 3'b_000
+funct3_PRIV   :: MachineInt;    funct3_PRIV   = 0b000
 --- SYSTEM.PRIV sub-sub-opcodes
-funct12_ECALL    :: MachineInt;    funct12_ECALL  = 0x000    -- 12'b_0000_0000_0000
-funct12_EBREAK   :: MachineInt;    funct12_EBREAK = 0x001    -- 12'b_0000_0000_0001
-funct12_URET     :: MachineInt;    funct12_URET   = 0x002    -- 12'b_0000_0000_0010
-funct12_SRET     :: MachineInt;    funct12_SRET   = 0x102    -- 12'b_0001_0000_0010
-funct12_MRET     :: MachineInt;    funct12_MRET   = 0x302    -- 12'b_0011_0000_0010
-funct12_WFI      :: MachineInt;    funct12_WFI    = 0x105    -- 12'b_0001_0000_0101
+funct12_ECALL    :: MachineInt;    funct12_ECALL  = 0b000000000000
+funct12_EBREAK   :: MachineInt;    funct12_EBREAK = 0b000000000001
+funct12_URET     :: MachineInt;    funct12_URET   = 0b000000000010
+funct12_SRET     :: MachineInt;    funct12_SRET   = 0b000100000010
+funct12_MRET     :: MachineInt;    funct12_MRET   = 0b001100000010
+funct12_WFI      :: MachineInt;    funct12_WFI    = 0b000100000101
 
-funct7_SFENCE_VM :: MachineInt;    funct7_SFENCE_VM = 0x09     -- 7'b_000_1001
+funct7_SFENCE_VM :: MachineInt;    funct7_SFENCE_VM = 0b0001001
 
-funct3_CSRRW  :: MachineInt;    funct3_CSRRW  = 0x1     -- 3'b_001
-funct3_CSRRS  :: MachineInt;    funct3_CSRRS  = 0x2     -- 3'b_010
-funct3_CSRRC  :: MachineInt;    funct3_CSRRC  = 0x3     -- 3'b_011
-funct3_CSRRWI :: MachineInt;    funct3_CSRRWI = 0x5     -- 3'b_101
-funct3_CSRRSI :: MachineInt;    funct3_CSRRSI = 0x6     -- 3'b_110
-funct3_CSRRCI :: MachineInt;    funct3_CSRRCI = 0x7     -- 3'b_111
+funct3_CSRRW  :: MachineInt;    funct3_CSRRW  = 0b001
+funct3_CSRRS  :: MachineInt;    funct3_CSRRS  = 0b010
+funct3_CSRRC  :: MachineInt;    funct3_CSRRC  = 0b011
+funct3_CSRRWI :: MachineInt;    funct3_CSRRWI = 0b101
+funct3_CSRRSI :: MachineInt;    funct3_CSRRSI = 0b110
+funct3_CSRRCI :: MachineInt;    funct3_CSRRCI = 0b111
 
 -- TODO: sub-opcodes for LOAD_FP, STORE_FP, OP_FP
 -- TODO: sub-opcodes for AMO


### PR DESCRIPTION
Haskell supports binary literals, so let's use them for numbers which are specified in binary