### PR TITLE
Remove unnecessary conversions in ExecuteA/A64.hs

### DIFF
--- a/src/Spec/ExecuteA.hs
+++ b/src/Spec/ExecuteA.hs
@@ -68,27 +68,27 @@ execute (Amomax_w rd rs1 rs2 aqrl) = do
   x <- loadWord addr
   y <- getRegister rs2
   setRegister rd (int32ToReg x)
-  storeWord addr (regToInt32 (if x > (regToInt32 y) then x else regToInt32 y))
+  storeWord addr (if x > (regToInt32 y) then x else regToInt32 y)
 execute (Amomaxu_w rd rs1 rs2 aqrl) = do
   a <- getRegister rs1
   addr <- translate Store 4 a
   x <- loadWord addr
   y <- getRegister rs2
   setRegister rd (int32ToReg x)
-  storeWord addr (regToInt32 (if ltu (regToInt32 y) x then x else regToInt32 y))
+  storeWord addr (if ltu (regToInt32 y) x then x else regToInt32 y)
 execute (Amomin_w rd rs1 rs2 aqrl) = do
   a <- getRegister rs1
   addr <- translate Store 4 a
   x <- loadWord addr
   y <- getRegister rs2
   setRegister rd (int32ToReg x)
-  storeWord addr (regToInt32 (if x < (regToInt32 y) then x else (regToInt32 y)))
+  storeWord addr (if x < (regToInt32 y) then x else (regToInt32 y))
 execute (Amominu_w rd rs1 rs2 aqrl) = do
   a <- getRegister rs1
   addr <- translate Store 4 a
   x <- loadWord addr
   y <- getRegister rs2
   setRegister rd (int32ToReg x)
-  storeWord addr (regToInt32 (if ltu x (regToInt32 y) then x else (regToInt32 y)))
+  storeWord addr (if ltu x (regToInt32 y) then x else (regToInt32 y))
 -- end ast
 execute inst = error $ "dispatch bug: " ++ show inst

--- a/src/Spec/ExecuteA64.hs
+++ b/src/Spec/ExecuteA64.hs
@@ -68,27 +68,27 @@ execute (Amomax_d rd rs1 rs2 aqrl) = do
   x <- loadDouble addr
   y <- getRegister rs2
   setRegister rd (int64ToReg x)
-  storeDouble addr (regToInt64 (if x > (regToInt64 y) then x else regToInt64 y))
+  storeDouble addr (if x > (regToInt64 y) then x else regToInt64 y)
 execute (Amomaxu_d rd rs1 rs2 aqrl) = do
   a <- getRegister rs1
   addr <- translate Store 4 a
   x <- loadDouble addr
   y <- getRegister rs2
   setRegister rd (int64ToReg x)
-  storeDouble addr (regToInt64 (if ltu (regToInt64 y) x then x else regToInt64 y))
+  storeDouble addr (if ltu (regToInt64 y) x then x else regToInt64 y)
 execute (Amomin_d rd rs1 rs2 aqrl) = do
   a <- getRegister rs1
   addr <- translate Store 4 a
   x <- loadDouble addr
   y <- getRegister rs2
   setRegister rd (int64ToReg x)
-  storeDouble addr (regToInt64 (if x < (regToInt64 y) then x else (regToInt64 y)))
+  storeDouble addr (if x < (regToInt64 y) then x else (regToInt64 y))
 execute (Amominu_d rd rs1 rs2 aqrl) = do
   a <- getRegister rs1
   addr <- translate Store 4 a
   x <- loadDouble addr
   y <- getRegister rs2
   setRegister rd (int64ToReg x)
-  storeDouble addr (regToInt64 (if ltu x (regToInt64 y) then x else (regToInt64 y)))
+  storeDouble addr (if ltu x (regToInt64 y) then x else (regToInt64 y))
 -- end ast
 execute inst = error $ "dispatch bug: " ++ show inst


### PR DESCRIPTION
I believe some conversions are unnecessary, but I didn’t compile and test the project, lacking the required toolchain.

Reasoning:
Variable x has "type" int32 or int64.
Variable y has "type" Register.
We want to store something of "type" int32 or int64.
So the only necessary conversion is the one converting y to int32/int64.

After calculating the value we don’t have to convert it from int32/int64 to
int32/int64 as if it had been a value of "type" Register.