### PR TITLE
Fix RV64 divw/divuw/remw/remuw to truncate operands to 32 bits

### DIFF
--- a/src/Spec/ExecuteM64.hs
+++ b/src/Spec/ExecuteM64.hs
@@ -14,28 +14,36 @@ execute (Mulw rd rs1 rs2) = do
 execute (Divw rd rs1 rs2) = do
   x <- getRegister rs1
   y <- getRegister rs2
-  let q | x == minSigned && y == -1 = x
-        | y == 0 = -1
-        | otherwise = quot x y
+  let a = s32 x
+      b = s32 y
+      q | a == -2147483648 && b == -1 = a
+        | b == 0 = -1
+        | otherwise = quot a b
     in setRegister rd (s32 q)
 execute (Divuw rd rs1 rs2) = do
   x <- getRegister rs1
   y <- getRegister rs2
-  let q | y == 0 = maxUnsigned
-        | otherwise = divu x y
+  let a = u32 x
+      b = u32 y
+      q | b == 0 = maxUnsigned
+        | otherwise = divu a b
     in setRegister rd (s32 q)
 execute (Remw rd rs1 rs2) = do
   x <- getRegister rs1
   y <- getRegister rs2
-  let r | x == minSigned && y == -1 = 0
-        | y == 0 = x
-        | otherwise = rem x y
+  let a = s32 x
+      b = s32 y
+      r | a == -2147483648 && b == -1 = 0
+        | b == 0 = a
+        | otherwise = rem a b
     in setRegister rd (s32 r)
 execute (Remuw rd rs1 rs2) = do
   x <- getRegister rs1
   y <- getRegister rs2
-  let r | y == 0 = x
-        | otherwise = remu x y
+  let a = u32 x
+      b = u32 y
+      r | b == 0 = a
+        | otherwise = remu a b
     in setRegister rd (s32 r)
 -- end ast
 execute inst = error $ "dispatch bug: " ++ show inst

--- a/src/Spec/ExecuteM64.hs
+++ b/src/Spec/ExecuteM64.hs
@@ -16,7 +16,7 @@ execute (Divw rd rs1 rs2) = do
   y <- getRegister rs2
   let a = s32 x
       b = s32 y
-      q | a == -2147483648 && b == -1 = a
+      q | a == minSigned32 && b == -1 = a
         | b == 0 = -1
         | otherwise = quot a b
     in setRegister rd (s32 q)
@@ -33,7 +33,7 @@ execute (Remw rd rs1 rs2) = do
   y <- getRegister rs2
   let a = s32 x
       b = s32 y
-      r | a == -2147483648 && b == -1 = 0
+      r | a == minSigned32 && b == -1 = 0
         | b == 0 = a
         | otherwise = rem a b
     in setRegister rd (s32 r)

--- a/src/Utility/Utility.hs
+++ b/src/Utility/Utility.hs
@@ -29,7 +29,7 @@ u32 n = (fromIntegral:: Word32 -> t) ((fromIntegral:: t -> Word32) n)
 -- | INT32_MIN, the signed-overflow operand of the RV64 W-form
 -- divisions/remainders (after truncation to 32 bits).
 minSigned32 :: forall t. (Integral t) => t
-minSigned32 = -2147483648
+minSigned32 = - 2^31
 {-# INLINE minSigned32 #-}
 
 lower :: forall a b. (Bits a, Integral a, Num b) => Int -> a -> b

--- a/src/Utility/Utility.hs
+++ b/src/Utility/Utility.hs
@@ -26,6 +26,12 @@ u32 :: forall t. (Integral t) => t -> t
 u32 n = (fromIntegral:: Word32 -> t) ((fromIntegral:: t -> Word32) n)
 {-# INLINE u32 #-}
 
+-- | INT32_MIN, the signed-overflow operand of the RV64 W-form
+-- divisions/remainders (after truncation to 32 bits).
+minSigned32 :: forall t. (Integral t) => t
+minSigned32 = -2147483648
+{-# INLINE minSigned32 #-}
+
 lower :: forall a b. (Bits a, Integral a, Num b) => Int -> a -> b
 lower n x = (fromIntegral:: a -> b) $ bitSlice x 0 n
 {-# INLINE lower #-}


### PR DESCRIPTION
On RV64, the W-form divisions (`divw`/`divuw`/`remw`/`remuw`) must divide the **lower 32 bits** of each operand and sign-extend the 32-bit result. `ExecuteM64.hs` instead divided the full 64-bit register values and sign-extended only the result, so the model disagrees with hardware/qemu whenever an operand has live bits above bit 31 — including the *canonical* sign-extended `INT32_MIN` input for `divuw`/`remuw`. The zero-divisor and signed-overflow guards were likewise tested on the untruncated 64-bit values.

This fixes it by truncating both operands first — `s32` for the signed ops, `u32` for the unsigned ops — and evaluating the guards on the truncated values, matching the RISC-V unprivileged spec (M extension, RV64M). `mulw` is unaffected (its low 32 bits depend only on the operands' low 32 bits).

Verified against an independent 32-bit reference implementation: all rows of the divergence table in mit-plv/riscv-coq#48 now match hardware, plus 1296 randomized cross-checks across all four ops (value set covering sign boundaries and above-bit-31 inputs) pass.

Fixes the root cause of mit-plv/riscv-coq#48. The regenerated Coq (`hs-to-coq`) lands in a companion riscv-coq PR.

Written by Claude (Anthropic AI) at the request of and under the supervision of @JasonGross.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ttctspSoVoquHLQtbPVZw